### PR TITLE
Makes bundle install cacheable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,13 @@ RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
 
 RUN gem install bundler
 
+# Copy the Gemfile and Gemfile.lock into the image
+# This is seperate from the rest of the application files to make
+# docker cache the bundle install step if the Gemfile is unchanged
+ONBUILD WORKDIR /tmp
+ONBUILD ADD Gemfile /tmp/Gemfile
+ONBUILD ADD Gemfile.lock /tmp/Gemfile.lock
+ONBUILD RUN [ ! -e /tmp/Gemfile ] || bundle install --system
+
 ONBUILD ADD . /usr/src/app
 ONBUILD WORKDIR /usr/src/app
-ONBUILD RUN [ ! -e Gemfile ] || bundle install --system


### PR DESCRIPTION
# Problem

As of now, every time any file in the ruby source that is added (to
/usr/src/app) is changed, bundle install is rerun. This is unnecessary
and can take a substantial amount of time.
# Solution

By copying the Gemfile and Gemfile.lock seperately, Docker can cache the
ADD and the subsequent bundle install. Bundle install will only be rerun
when there is a change in the Gemfile or the Gemfile.lock

This solution is based on:
- http://ilikestuffblog.com/2014/01/06/how-to-skip-bundle-install-when-
  deploying-a-rails-app-to-docker/
- https://blog.abevoelker.com/rails-development-using-docker-and-
  vagrant/
