### PR TITLE
Add '--jobs 4' to 'bundle install'

### DIFF
--- a/docker-onbuild/Dockerfile
+++ b/docker-onbuild/Dockerfile
@@ -2,4 +2,4 @@ FROM ruby:2.1.2
 
 ONBUILD ADD . /usr/src/app
 ONBUILD WORKDIR /usr/src/app
-ONBUILD RUN [ ! -e Gemfile ] || bundle install --system
+ONBUILD RUN [ ! -e Gemfile ] || bundle install --system --jobs 4


### PR DESCRIPTION
"Install gems parallely by starting the number of workers specificed."

``` bash
$ bundle install --jobs 4
```

Source: http://bundler.io/v1.6/bundle_install.html
