### PR TITLE
Cleaning up apt cache to optimize disk space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM buildpack-deps
 RUN useradd -g users user
 
 RUN apt-get update && apt-get install -y bison procps \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/*
 
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built
 RUN apt-get update && apt-get install -y ruby \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/*
 
 ADD . /usr/src/ruby
 WORKDIR /usr/src/ruby


### PR DESCRIPTION
I tested it and got this :
before : 1.561 GB
after : 1.529 GB
All this 32MB is unnecessary files, as recommended in Debian mkimage :
"delete all the apt list files since they're big and get stale quickly
this forces "apt-get update" in dependent images, which is also good"
https://github.com/docker/docker/blob/master/contrib/mkimage/debootstrap
