### PR TITLE
add the whole directory to the image before bundle install

### DIFF
--- a/1.9/onbuild/Dockerfile
+++ b/1.9/onbuild/Dockerfile
@@ -3,8 +3,5 @@ FROM ruby:1.9.3-p547
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ONBUILD ADD Gemfile /usr/src/app/
-ONBUILD ADD Gemfile.lock /usr/src/app/
-ONBUILD RUN bundle install --system
-
 ONBUILD ADD . /usr/src/app
+ONBUILD RUN bundle install --system

--- a/2.0/onbuild/Dockerfile
+++ b/2.0/onbuild/Dockerfile
@@ -3,8 +3,5 @@ FROM ruby:2.0.0-p576
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ONBUILD ADD Gemfile /usr/src/app/
-ONBUILD ADD Gemfile.lock /usr/src/app/
-ONBUILD RUN bundle install --system
-
 ONBUILD ADD . /usr/src/app
+ONBUILD RUN bundle install --system

--- a/2.1/onbuild/Dockerfile
+++ b/2.1/onbuild/Dockerfile
@@ -3,8 +3,5 @@ FROM ruby:2.1.3
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ONBUILD ADD Gemfile /usr/src/app/
-ONBUILD ADD Gemfile.lock /usr/src/app/
-ONBUILD RUN bundle install --system
-
 ONBUILD ADD . /usr/src/app
+ONBUILD RUN bundle install --system


### PR DESCRIPTION
I ran into an issue trying to use this onbuild file to create a test environment for one of my gem projects, since the Gemfile has a `gemspec` directive, so bundler wants to read my gemspec file as well, and can't find it.

I didn't see a reason not to just add the whole project before running `bundle install`, let me know if I'm missing something.
