### PR TITLE
Simplify bundler config so "bundle install" does the right thing by default

### DIFF
--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -22,8 +22,16 @@ RUN apt-get update \
 	&& rm -r /usr/src/ruby
 
 # skip installing gem documentation
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-rdoc --no-ri' >> "$HOME/.gemrc"
 
-RUN gem install bundler
+# install things globally, for great justice
+ENV GEM_HOME /usr/local/bundle
+ENV PATH $GEM_HOME/bin:$PATH
+RUN gem install bundler \
+	&& bundle config --global path "$GEM_HOME" \
+	&& bundle config --global bin "$GEM_HOME/bin"
+
+# don't create ".bundle" in all our apps
+ENV BUNDLE_APP_CONFIG $GEM_HOME
 
 CMD [ "irb" ]

--- a/1.9/onbuild/Dockerfile
+++ b/1.9/onbuild/Dockerfile
@@ -1,10 +1,13 @@
 FROM ruby:1.9.3-p547
 
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ONBUILD ADD Gemfile /usr/src/app/
-ONBUILD ADD Gemfile.lock /usr/src/app/
-ONBUILD RUN bundle install --system
+ONBUILD COPY Gemfile /usr/src/app/
+ONBUILD COPY Gemfile.lock /usr/src/app/
+ONBUILD RUN bundle install
 
-ONBUILD ADD . /usr/src/app
+ONBUILD COPY . /usr/src/app

--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -22,8 +22,16 @@ RUN apt-get update \
 	&& rm -r /usr/src/ruby
 
 # skip installing gem documentation
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-rdoc --no-ri' >> "$HOME/.gemrc"
 
-RUN gem install bundler
+# install things globally, for great justice
+ENV GEM_HOME /usr/local/bundle
+ENV PATH $GEM_HOME/bin:$PATH
+RUN gem install bundler \
+	&& bundle config --global path "$GEM_HOME" \
+	&& bundle config --global bin "$GEM_HOME/bin"
+
+# don't create ".bundle" in all our apps
+ENV BUNDLE_APP_CONFIG $GEM_HOME
 
 CMD [ "irb" ]

--- a/2.0/onbuild/Dockerfile
+++ b/2.0/onbuild/Dockerfile
@@ -1,10 +1,13 @@
 FROM ruby:2.0.0-p576
 
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ONBUILD ADD Gemfile /usr/src/app/
-ONBUILD ADD Gemfile.lock /usr/src/app/
-ONBUILD RUN bundle install --system
+ONBUILD COPY Gemfile /usr/src/app/
+ONBUILD COPY Gemfile.lock /usr/src/app/
+ONBUILD RUN bundle install
 
-ONBUILD ADD . /usr/src/app
+ONBUILD COPY . /usr/src/app

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -22,8 +22,16 @@ RUN apt-get update \
 	&& rm -r /usr/src/ruby
 
 # skip installing gem documentation
-RUN echo 'gem: --no-rdoc --no-ri' >> /.gemrc
+RUN echo 'gem: --no-rdoc --no-ri' >> "$HOME/.gemrc"
 
-RUN gem install bundler
+# install things globally, for great justice
+ENV GEM_HOME /usr/local/bundle
+ENV PATH $GEM_HOME/bin:$PATH
+RUN gem install bundler \
+	&& bundle config --global path "$GEM_HOME" \
+	&& bundle config --global bin "$GEM_HOME/bin"
+
+# don't create ".bundle" in all our apps
+ENV BUNDLE_APP_CONFIG $GEM_HOME
 
 CMD [ "irb" ]

--- a/2.1/onbuild/Dockerfile
+++ b/2.1/onbuild/Dockerfile
@@ -1,10 +1,13 @@
 FROM ruby:2.1.3
 
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-ONBUILD ADD Gemfile /usr/src/app/
-ONBUILD ADD Gemfile.lock /usr/src/app/
-ONBUILD RUN bundle install --system
+ONBUILD COPY Gemfile /usr/src/app/
+ONBUILD COPY Gemfile.lock /usr/src/app/
+ONBUILD RUN bundle install
 
-ONBUILD ADD . /usr/src/app
+ONBUILD COPY . /usr/src/app


### PR DESCRIPTION
This also makes it so that when we `ONBUILD RUN bundle install` it doesn't create `.bundle/config` in our precious, pristine application directory, and makes all the bundler-installed Gems show up in `gem list`.

I'm also sneaking in a change to the `onbuild` variants that makes `bundle install` just fail if you've updated your `Gemfile` but not your `Gemfile.lock`, since that bit me pretty hard while testing this (ie, `bundle install` was silently updating `Gemfile.lock`, which changes were then clobbered by the `COPY . /usr/src/app` and the application wouldn't run).  I _think_ this might actually be the real issue in https://github.com/docker-library/rails/issues/11, too.
