### PR TITLE
update rubygems to 2.4.8

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -3,6 +3,7 @@ FROM buildpack-deps:jessie
 ENV RUBY_MAJOR 2.0
 ENV RUBY_VERSION 2.0.0-p645
 ENV RUBY_DOWNLOAD_SHA256 5e9f8effffe97cba5ef0015feec6e1e5f3bacf6ace78cd1cdf72708cd71cf4ab
+ENV RUBYGEMS_VERSION 2.4.8
 
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built
@@ -20,6 +21,7 @@ RUN apt-get update \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& apt-get purge -y --auto-remove bison libgdbm-dev ruby \
+	&& gem update --no-document --system $RUBYGEMS_VERSION \
 	&& rm -r /usr/src/ruby
 
 # skip installing gem documentation

--- a/2.0/slim/Dockerfile
+++ b/2.0/slim/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 
 ENV RUBY_MAJOR 2.0
 ENV RUBY_VERSION 2.0.0-p645
+ENV RUBYGEMS_VERSION 2.4.8
 
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built
@@ -44,6 +45,7 @@ RUN buildDeps=' \
 	&& ./configure --disable-install-doc \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& gem update --no-document --system $RUBYGEMS_VERSION \
 	&& rm -r /usr/src/ruby \
 	&& apt-get purge -y --auto-remove $buildDeps
 

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -3,6 +3,7 @@ FROM buildpack-deps:jessie
 ENV RUBY_MAJOR 2.1
 ENV RUBY_VERSION 2.1.6
 ENV RUBY_DOWNLOAD_SHA256 1e1362ae7427c91fa53dc9c05aee4ee200e2d7d8970a891c5bd76bee28d28be4
+ENV RUBYGEMS_VERSION 2.4.8
 
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built
@@ -20,6 +21,7 @@ RUN apt-get update \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& apt-get purge -y --auto-remove bison libgdbm-dev ruby \
+	&& gem update --no-document --system $RUBYGEMS_VERSION \
 	&& rm -r /usr/src/ruby
 
 # skip installing gem documentation

--- a/2.1/slim/Dockerfile
+++ b/2.1/slim/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 
 ENV RUBY_MAJOR 2.1
 ENV RUBY_VERSION 2.1.6
+ENV RUBYGEMS_VERSION 2.4.8
 
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built
@@ -44,6 +45,7 @@ RUN buildDeps=' \
 	&& ./configure --disable-install-doc \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& gem update --no-document --system $RUBYGEMS_VERSION \
 	&& rm -r /usr/src/ruby \
 	&& apt-get purge -y --auto-remove $buildDeps
 

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -3,6 +3,7 @@ FROM buildpack-deps:jessie
 ENV RUBY_MAJOR 2.2
 ENV RUBY_VERSION 2.2.2
 ENV RUBY_DOWNLOAD_SHA256 5ffc0f317e429e6b29d4a98ac521c3ce65481bfd22a8cf845fa02a7b113d9b44
+ENV RUBYGEMS_VERSION 2.4.8
 
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built
@@ -20,6 +21,7 @@ RUN apt-get update \
 	&& make -j"$(nproc)" \
 	&& make install \
 	&& apt-get purge -y --auto-remove bison libgdbm-dev ruby \
+	&& gem update --no-document --system $RUBYGEMS_VERSION \
 	&& rm -r /usr/src/ruby
 
 # skip installing gem documentation

--- a/2.2/slim/Dockerfile
+++ b/2.2/slim/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
 
 ENV RUBY_MAJOR 2.2
 ENV RUBY_VERSION 2.2.2
+ENV RUBYGEMS_VERSION 2.4.8
 
 # some of ruby's build scripts are written in ruby
 # we purge this later to make sure our final image uses what we just built
@@ -44,6 +45,7 @@ RUN buildDeps=' \
 	&& ./configure --disable-install-doc \
 	&& make -j"$(nproc)" \
 	&& make install \
+	&& gem update --no-document --system $RUBYGEMS_VERSION \
 	&& rm -r /usr/src/ruby \
 	&& apt-get purge -y --auto-remove $buildDeps
 

--- a/update.sh
+++ b/update.sh
@@ -10,7 +10,12 @@ fi
 versions=( "${versions[@]%/}" )
 shaPage=$(curl -fsSL 'https://www.ruby-lang.org/en/downloads/')
 
-bundler="$(curl -sSL 'https://rubygems.org/api/v1/gems/bundler.json' | sed -r 's/^.*"version":"([^"]+)".*$/\1/')"
+latest_gem_version() {
+	curl -sSL "https://rubygems.org/api/v1/gems/$1.json" | sed -r 's/^.*"version":"([^"]+)".*$/\1/'
+}
+
+rubygems="$(latest_gem_version rubygems-update)"
+bundler="$(latest_gem_version bundler)"
 
 for version in "${versions[@]}"; do
 	fullVersion="$(curl -sSL --compressed "http://cache.ruby-lang.org/pub/ruby/$version/" \
@@ -26,6 +31,7 @@ for version in "${versions[@]}"; do
 			s/^(ENV RUBY_VERSION) .*/\1 '"$fullVersion"'/;
 			s/^(ENV RUBY_DOWNLOAD_SHA256) .*/\1 '"$shaVal"'/;
 			s/^(ENV BUNDLER_VERSION) .*/\1 '"$bundler"'/;
+			s/^(ENV RUBYGEMS_VERSION) .*/\1 '"$rubygems"'/;
 		' "$version/"{,slim/}Dockerfile
 		sed -ri 's/^(FROM ruby):.*/\1:'"$fullVersion"'/' "$version/"*"/Dockerfile"
 	)


### PR DESCRIPTION
Closes #47, but I need to rebase it into a single commit before it can be merged.

To reiterate the issue, the idea is to explicitly manage rubygems versions, just as is done with bundler.