### PR TITLE
Fix non-root support

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -40,18 +40,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.0/slim/Dockerfile
+++ b/2.0/slim/Dockerfile
@@ -62,18 +62,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -40,18 +40,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -75,18 +75,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.1/slim/Dockerfile
+++ b/2.1/slim/Dockerfile
@@ -62,18 +62,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -40,18 +40,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -75,18 +75,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.2/slim/Dockerfile
+++ b/2.2/slim/Dockerfile
@@ -62,18 +62,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -40,18 +40,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.3/alpine/Dockerfile
+++ b/2.3/alpine/Dockerfile
@@ -75,18 +75,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/2.3/slim/Dockerfile
+++ b/2.3/slim/Dockerfile
@@ -62,18 +62,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION 1.11.2
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -75,18 +75,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION %%BUNDLER%%
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -62,18 +62,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION %%BUNDLER%%
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -40,18 +40,17 @@ RUN set -ex \
 
 ENV BUNDLER_VERSION %%BUNDLER%%
 
-RUN gem install bundler --version "$BUNDLER_VERSION" \
-	&& bundle config --global path "$GEM_HOME" \
-	&& bundle config --global bin "$GEM_HOME/bin" \
-	&& bundle config --global silence_root_warning true
+RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
+# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV PATH $GEM_HOME/bin:$PATH
-RUN mkdir -p "$GEM_HOME" \
-	&& chmod 777 "$GEM_HOME"
-
-# don't create ".bundle" in all our apps
-ENV BUNDLE_APP_CONFIG $GEM_HOME
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 
 CMD [ "irb" ]


### PR DESCRIPTION
I'm a little :sheep:ish...  This was writing to `/root/.bundle/config`, and using environment variables before they existed.  Since Bundler supports environment variables for _all_ settings, let's use those instead so that this _actually_ works properly. :+1:

Fixes the shortcoming of #68 (for backlink references).