### PR TITLE
Build dynamic library (libruby.so)

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -44,7 +44,7 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc \
+	&& ./configure --disable-install-doc --enable-shared \
 	&& make -j"$(nproc)" \
 	&& make install \
 	\

--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -64,7 +64,7 @@ RUN set -ex \
 	&& autoconf \
 # the configure script does not detect isnan/isinf as macros
 	&& ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
-		./configure --disable-install-doc \
+		./configure --disable-install-doc --enable-shared \
 	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\

--- a/2.1/slim/Dockerfile
+++ b/2.1/slim/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc \
+	&& ./configure --disable-install-doc --enable-shared \
 	&& make -j"$(nproc)" \
 	&& make install \
 	\

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -44,7 +44,7 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc \
+	&& ./configure --disable-install-doc --enable-shared \
 	&& make -j"$(nproc)" \
 	&& make install \
 	\

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -64,7 +64,7 @@ RUN set -ex \
 	&& autoconf \
 # the configure script does not detect isnan/isinf as macros
 	&& ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
-		./configure --disable-install-doc \
+		./configure --disable-install-doc --enable-shared \
 	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\

--- a/2.2/slim/Dockerfile
+++ b/2.2/slim/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc \
+	&& ./configure --disable-install-doc --enable-shared \
 	&& make -j"$(nproc)" \
 	&& make install \
 	\

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -44,7 +44,7 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc \
+	&& ./configure --disable-install-doc --enable-shared \
 	&& make -j"$(nproc)" \
 	&& make install \
 	\

--- a/2.3/alpine/Dockerfile
+++ b/2.3/alpine/Dockerfile
@@ -64,7 +64,7 @@ RUN set -ex \
 	&& autoconf \
 # the configure script does not detect isnan/isinf as macros
 	&& ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
-		./configure --disable-install-doc \
+		./configure --disable-install-doc --enable-shared \
 	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\

--- a/2.3/slim/Dockerfile
+++ b/2.3/slim/Dockerfile
@@ -66,7 +66,7 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc \
+	&& ./configure --disable-install-doc --enable-shared \
 	&& make -j"$(nproc)" \
 	&& make install \
 	\

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -64,7 +64,7 @@ RUN set -ex \
 	&& autoconf \
 # the configure script does not detect isnan/isinf as macros
 	&& ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
-		./configure --disable-install-doc \
+		./configure --disable-install-doc --enable-shared \
 	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
 	&& make install \
 	\

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -66,7 +66,7 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc \
+	&& ./configure --disable-install-doc --enable-shared \
 	&& make -j"$(nproc)" \
 	&& make install \
 	\

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -44,7 +44,7 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc \
+	&& ./configure --disable-install-doc --enable-shared \
 	&& make -j"$(nproc)" \
 	&& make install \
 	\


### PR DESCRIPTION
This PR adds `libruby.so` to the Ruby 2.1, 2.2, and 2.3 images by passing the `--enable-shared` flag to the `./configure` call.

I ran into issues when trying to run a Ruby app with a native library that had to be linked against `libruby.so` in Docker. Since the Ruby base image don't have it, I got `libruby.so.2.3: cannot open shared object file: No such file or directory`. This seems like a use-case that should probably be supported by the Ruby Docker images. Thus this PR.

It seems to add a few megabytes to the image size (3.6, 3.4, 2.5 MB for Ruby 2.1, 2.2, and 2.3, respectively), but AFAICT it shouldn't have any adverse consequences otherwise.