### PR TITLE
2.4 is latest

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,7 @@
 set -eu
 
 declare -A aliases=(
-	[2.3]='2 latest'
+	[2.4]='2 latest'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
Since Ruby 2.4 is the latest release, it should be considered the default ‘2’ version.