### PR TITLE
Replace openssl with libressl in Alpine Images

### DIFF
--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -12,6 +12,8 @@ ENV RUBY_VERSION 2.1.10
 ENV RUBY_DOWNLOAD_SHA256 5be9f8d5d29d252cd7f969ab7550e31bbb001feb4a83532301c0dd3b5006e148
 ENV RUBYGEMS_VERSION 2.6.8
 
+ADD patch/ruby-randegd.patch /tmp/ruby-randegd.patch
+
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
 # readline-dev vs libedit-dev: https://bugs.ruby-lang.org/issues/11869 and https://github.com/docker-library/ruby/issues/75
@@ -61,6 +63,9 @@ RUN set -ex \
 		cat file.c; \
 	} > file.c.new \
 	&& mv file.c.new file.c \
+	\
+	&& patch -p0 < /tmp/ruby-randegd.patch \
+	&& rm /tmp/ruby-randegd.patch \
 	\
 	&& autoconf \
 # the configure script does not detect isnan/isinf as macros

--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -34,8 +34,8 @@ RUN set -ex \
 		linux-headers \
 		make \
 		ncurses-dev \
-		openssl \
-		openssl-dev \
+		libressl \
+		libressl-dev \
 		procps \
 		readline-dev \
 		ruby \
@@ -80,7 +80,7 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		openssl-dev \
+		libressl-dev \
 		yaml-dev \
 		procps \
 		zlib-dev \

--- a/2.1/alpine/patch/ruby-randegd.patch
+++ b/2.1/alpine/patch/ruby-randegd.patch
@@ -1,0 +1,44 @@
+diff --git ext/openssl/extconf.rb ext/openssl/extconf.rb
+index c2fc8b0..39e091d 100644
+--- ext/openssl/extconf.rb
++++ ext/openssl/extconf.rb
+@@ -87,6 +87,7 @@ have_func("HMAC_CTX_init")
+ have_func("PEM_def_callback")
+ have_func("PKCS5_PBKDF2_HMAC")
+ have_func("PKCS5_PBKDF2_HMAC_SHA1")
++have_func("RAND_egd")
+ have_func("X509V3_set_nconf")
+ have_func("X509V3_EXT_nconf_nid")
+ have_func("X509_CRL_add0_revoked")
+diff --git ext/openssl/ossl_rand.c ext/openssl/ossl_rand.c
+index abd1809..63c3c20 100644
+--- ext/openssl/ossl_rand.c
++++ ext/openssl/ossl_rand.c
+@@ -125,6 +125,8 @@ ossl_rand_pseudo_bytes(VALUE self, VALUE len)
+     return str;
+ }
+ 
++#ifdef HAVE_RAND_EGD
++
+ /*
+  *  call-seq:
+  *     egd(filename) -> true
+@@ -158,6 +160,7 @@ ossl_rand_egd_bytes(VALUE self, VALUE filename, VALUE len)
+     }
+     return Qtrue;
+ }
++#endif /* HAVE_RAND_EGD */
+ 
+ /*
+  *  call-seq:
+@@ -195,8 +198,10 @@ Init_ossl_rand()
+     DEFMETH(mRandom, "write_random_file", ossl_rand_write_file, 1);
+     DEFMETH(mRandom, "random_bytes", ossl_rand_bytes, 1);
+     DEFMETH(mRandom, "pseudo_bytes", ossl_rand_pseudo_bytes, 1);
++#ifdef HAVE_RAND_EGD
+     DEFMETH(mRandom, "egd", ossl_rand_egd, 1);
+     DEFMETH(mRandom, "egd_bytes", ossl_rand_egd_bytes, 2);
++#endif /* HAVE_RAND_EGD */
+     DEFMETH(mRandom, "status?", ossl_rand_status, 0)
+ }
+ 

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -34,8 +34,8 @@ RUN set -ex \
 		linux-headers \
 		make \
 		ncurses-dev \
-		openssl \
-		openssl-dev \
+		libressl \
+		libressl-dev \
 		procps \
 		readline-dev \
 		ruby \
@@ -80,7 +80,7 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		openssl-dev \
+		libressl-dev \
 		yaml-dev \
 		procps \
 		zlib-dev \

--- a/2.3/alpine/Dockerfile
+++ b/2.3/alpine/Dockerfile
@@ -34,8 +34,8 @@ RUN set -ex \
 		linux-headers \
 		make \
 		ncurses-dev \
-		openssl \
-		openssl-dev \
+		libressl \
+		libressl-dev \
 		procps \
 		readline-dev \
 		ruby \
@@ -80,7 +80,7 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		openssl-dev \
+		libressl-dev \
 		yaml-dev \
 		procps \
 		zlib-dev \

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -34,8 +34,8 @@ RUN set -ex \
 		linux-headers \
 		make \
 		ncurses-dev \
-		openssl \
-		openssl-dev \
+		libressl \
+		libressl-dev \
 		procps \
 		readline-dev \
 		ruby \
@@ -80,7 +80,7 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		openssl-dev \
+		libressl-dev \
 		yaml-dev \
 		procps \
 		zlib-dev \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -34,8 +34,8 @@ RUN set -ex \
 		linux-headers \
 		make \
 		ncurses-dev \
-		openssl \
-		openssl-dev \
+		libressl \
+		libressl-dev \
 		procps \
 		readline-dev \
 		ruby \
@@ -80,7 +80,7 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		openssl-dev \
+		libressl-dev \
 		yaml-dev \
 		procps \
 		zlib-dev \


### PR DESCRIPTION
should fix [#104](https://github.com/docker-library/ruby/issues/104)
Alpine 3.5 is also building ruby package with [libressl](http://git.alpinelinux.org/cgit/aports/tree/main/ruby/APKBUILD?h=3.5-stable)

make test pass on 2.1.x and 2.3.x, so also should on 2.2.x and 2.4.x