### PR TITLE
Change from ENV to ARG, add labels to allow inspect for versions

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,5 +1,8 @@
 FROM alpine:3.4
 
+LABEL rubyversion=%%FULL_VERSION%%
+LABEL rubygemsversion=%%RUBYGEMS%%
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -7,10 +10,10 @@ RUN mkdir -p /usr/local/etc \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
-ENV RUBY_MAJOR %%VERSION%%
-ENV RUBY_VERSION %%FULL_VERSION%%
-ENV RUBY_DOWNLOAD_SHA256 %%SHA256%%
-ENV RUBYGEMS_VERSION %%RUBYGEMS%%
+ARG RUBY_MAJOR %%VERSION%%
+ARG RUBY_VERSION %%FULL_VERSION%%
+ARG RUBY_DOWNLOAD_SHA256 %%SHA256%%
+ARG RUBYGEMS_VERSION %%RUBYGEMS%%
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -90,18 +93,20 @@ RUN set -ex \
 	\
 	&& gem update --system "$RUBYGEMS_VERSION"
 
-ENV BUNDLER_VERSION %%BUNDLER%%
+ARG BUNDLER_VERSION %%BUNDLER%%
 
 RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
-	BUNDLE_SILENCE_ROOT_WARNING=1 \
-	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
+ARG GEM_HOME /usr/local/bundle
+ARG BUNDLE_PATH="$GEM_HOME" 
+ARG BUNDLE_BIN="$GEM_HOME/bin" 
+ARG BUNDLE_APP_CONFIG="$GEM_HOME"
+ARG PATH $BUNDLE_BIN:$PATH
+
+ENV BUNDLE_SILENCE_ROOT_WARNING=1 
+
 RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
 	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -99,13 +99,12 @@ RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
-ARG GEM_HOME /usr/local/bundle
-ARG BUNDLE_PATH="$GEM_HOME" 
-ARG BUNDLE_BIN="$GEM_HOME/bin" 
-ARG BUNDLE_APP_CONFIG="$GEM_HOME"
-ARG PATH $BUNDLE_BIN:$PATH
-
-ENV BUNDLE_SILENCE_ROOT_WARNING=1 
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
 
 RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
 	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,5 +1,8 @@
 FROM debian:jessie
 
+LABEL rubyversion=%%FULL_VERSION%%
+LABEL rubygemsversion=%%RUBYGEMS%%
+
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		bzip2 \
@@ -19,10 +22,10 @@ RUN mkdir -p /usr/local/etc \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
-ENV RUBY_MAJOR %%VERSION%%
-ENV RUBY_VERSION %%FULL_VERSION%%
-ENV RUBY_DOWNLOAD_SHA256 %%SHA256%%
-ENV RUBYGEMS_VERSION %%RUBYGEMS%%
+ARG RUBY_MAJOR %%VERSION%%
+ARG RUBY_VERSION %%FULL_VERSION%%
+ARG RUBY_DOWNLOAD_SHA256 %%SHA256%%
+ARG RUBYGEMS_VERSION %%RUBYGEMS%%
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -77,18 +80,20 @@ RUN set -ex \
 	\
 	&& gem update --system "$RUBYGEMS_VERSION"
 
-ENV BUNDLER_VERSION %%BUNDLER%%
+ARG BUNDLER_VERSION %%BUNDLER%%
 
 RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
-	BUNDLE_SILENCE_ROOT_WARNING=1 \
-	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
+ARG GEM_HOME /usr/local/bundle
+ARG BUNDLE_PATH="$GEM_HOME" 
+ARG BUNDLE_BIN="$GEM_HOME/bin" 
+ARG BUNDLE_APP_CONFIG="$GEM_HOME"
+ARG PATH $BUNDLE_BIN:$PATH
+
+ENV BUNDLE_SILENCE_ROOT_WARNING=1 
+
 RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
 	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -86,13 +86,12 @@ RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
-ARG GEM_HOME /usr/local/bundle
-ARG BUNDLE_PATH="$GEM_HOME" 
-ARG BUNDLE_BIN="$GEM_HOME/bin" 
-ARG BUNDLE_APP_CONFIG="$GEM_HOME"
-ARG PATH $BUNDLE_BIN:$PATH
-
-ENV BUNDLE_SILENCE_ROOT_WARNING=1 
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
 
 RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
 	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,5 +1,8 @@
 FROM buildpack-deps:jessie
 
+LABEL rubyversion=%%FULL_VERSION%%
+LABEL rubygemsversion=%%RUBYGEMS%%
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -7,10 +10,10 @@ RUN mkdir -p /usr/local/etc \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
-ENV RUBY_MAJOR %%VERSION%%
-ENV RUBY_VERSION %%FULL_VERSION%%
-ENV RUBY_DOWNLOAD_SHA256 %%SHA256%%
-ENV RUBYGEMS_VERSION %%RUBYGEMS%%
+ARG RUBY_MAJOR %%VERSION%%
+ARG RUBY_VERSION %%FULL_VERSION%%
+ARG RUBY_DOWNLOAD_SHA256 %%SHA256%%
+ARG RUBYGEMS_VERSION %%RUBYGEMS%%
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -54,18 +57,20 @@ RUN set -ex \
 	\
 	&& gem update --system "$RUBYGEMS_VERSION"
 
-ENV BUNDLER_VERSION %%BUNDLER%%
+ARG BUNDLER_VERSION %%BUNDLER%%
 
 RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
-ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
-	BUNDLE_SILENCE_ROOT_WARNING=1 \
-	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
+ARG GEM_HOME /usr/local/bundle
+ARG BUNDLE_PATH="$GEM_HOME" 
+ARG BUNDLE_BIN="$GEM_HOME/bin" 
+ARG BUNDLE_APP_CONFIG="$GEM_HOME"
+ARG PATH $BUNDLE_BIN:$PATH
+
+ENV BUNDLE_SILENCE_ROOT_WARNING=1 
+
 RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
 	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -63,13 +63,12 @@ RUN gem install bundler --version "$BUNDLER_VERSION"
 
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
-ARG GEM_HOME /usr/local/bundle
-ARG BUNDLE_PATH="$GEM_HOME" 
-ARG BUNDLE_BIN="$GEM_HOME/bin" 
-ARG BUNDLE_APP_CONFIG="$GEM_HOME"
-ARG PATH $BUNDLE_BIN:$PATH
-
-ENV BUNDLE_SILENCE_ROOT_WARNING=1 
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
 
 RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
 	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"


### PR DESCRIPTION
Switches some of the ENV variables to ARG, adds labels to templates so that the images can be inspected/filtered by ruby version, ruby gems version. 

Fixes #111 