### PR TITLE
Update the alpine base image

### DIFF
--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \

--- a/2.3/alpine/Dockerfile
+++ b/2.3/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.5
 
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \


### PR DESCRIPTION
The alpine base image is already available in version 3.5. The ruby image should also use this version.