### PR TITLE
Add explicit "--build" to our "./configure" invocations

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
 	\
 	&& buildDeps=' \
 		bison \
+		dpkg-dev \
 		libgdbm-dev \
 		ruby \
 	' \
@@ -44,8 +45,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -24,6 +24,7 @@ RUN set -ex \
 		bzip2-dev \
 		ca-certificates \
 		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		glib-dev \
@@ -63,10 +64,14 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 # the configure script does not detect isnan/isinf as macros
-	&& ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
-		./configure --disable-install-doc --enable-shared \
-	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
+	&& export ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/2.1/slim/Dockerfile
+++ b/2.1/slim/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
 	&& buildDeps=' \
 		autoconf \
 		bison \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libgdbm-dev \
@@ -67,8 +68,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
 	\
 	&& buildDeps=' \
 		bison \
+		dpkg-dev \
 		libgdbm-dev \
 		ruby \
 	' \
@@ -44,8 +45,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -24,6 +24,7 @@ RUN set -ex \
 		bzip2-dev \
 		ca-certificates \
 		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		glib-dev \
@@ -63,10 +64,14 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 # the configure script does not detect isnan/isinf as macros
-	&& ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
-		./configure --disable-install-doc --enable-shared \
-	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
+	&& export ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/2.2/slim/Dockerfile
+++ b/2.2/slim/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
 	&& buildDeps=' \
 		autoconf \
 		bison \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libgdbm-dev \
@@ -67,8 +68,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/2.3/Dockerfile
+++ b/2.3/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
 	\
 	&& buildDeps=' \
 		bison \
+		dpkg-dev \
 		libgdbm-dev \
 		ruby \
 	' \
@@ -44,8 +45,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/2.3/alpine/Dockerfile
+++ b/2.3/alpine/Dockerfile
@@ -24,6 +24,7 @@ RUN set -ex \
 		bzip2-dev \
 		ca-certificates \
 		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		glib-dev \
@@ -63,10 +64,14 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 # the configure script does not detect isnan/isinf as macros
-	&& ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
-		./configure --disable-install-doc --enable-shared \
-	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
+	&& export ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/2.3/slim/Dockerfile
+++ b/2.3/slim/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
 	&& buildDeps=' \
 		autoconf \
 		bison \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libgdbm-dev \
@@ -67,8 +68,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
 	\
 	&& buildDeps=' \
 		bison \
+		dpkg-dev \
 		libgdbm-dev \
 		ruby \
 	' \
@@ -44,8 +45,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -24,6 +24,7 @@ RUN set -ex \
 		bzip2-dev \
 		ca-certificates \
 		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		glib-dev \
@@ -63,10 +64,14 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 # the configure script does not detect isnan/isinf as macros
-	&& ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
-		./configure --disable-install-doc --enable-shared \
-	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
+	&& export ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/2.4/slim/Dockerfile
+++ b/2.4/slim/Dockerfile
@@ -31,6 +31,7 @@ RUN set -ex \
 	&& buildDeps=' \
 		autoconf \
 		bison \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libgdbm-dev \
@@ -67,8 +68,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -24,6 +24,7 @@ RUN set -ex \
 		bzip2-dev \
 		ca-certificates \
 		coreutils \
+		dpkg-dev dpkg \
 		gcc \
 		gdbm-dev \
 		glib-dev \
@@ -63,10 +64,14 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
 # the configure script does not detect isnan/isinf as macros
-	&& ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
-		./configure --disable-install-doc --enable-shared \
-	&& make -j"$(getconf _NPROCESSORS_ONLN)" \
+	&& export ac_cv_func_isnan=yes ac_cv_func_isinf=yes \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& runDeps="$( \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -31,6 +31,7 @@ RUN set -ex \
 	&& buildDeps=' \
 		autoconf \
 		bison \
+		dpkg-dev \
 		gcc \
 		libbz2-dev \
 		libgdbm-dev \
@@ -67,8 +68,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -18,6 +18,7 @@ RUN set -ex \
 	\
 	&& buildDeps=' \
 		bison \
+		dpkg-dev \
 		libgdbm-dev \
 		ruby \
 	' \
@@ -44,8 +45,12 @@ RUN set -ex \
 	&& mv file.c.new file.c \
 	\
 	&& autoconf \
-	&& ./configure --disable-install-doc --enable-shared \
-	&& make -j"$(nproc)" \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
 	&& make install \
 	\
 	&& apt-get purge -y --auto-remove $buildDeps \


### PR DESCRIPTION
This is along the same lines as:

- https://github.com/docker-library/tomcat/pull/70
- https://github.com/docker-library/memcached/pull/13
- https://github.com/tianon/docker-bash/pull/3