### PR TITLE
Remove unnecessary ruby-libs package

### DIFF
--- a/2.1/alpine/Dockerfile
+++ b/2.1/alpine/Dockerfile
@@ -78,6 +78,7 @@ RUN set -ex \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
 			| sort -u \
+			| grep -v libruby \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \

--- a/2.2/alpine/Dockerfile
+++ b/2.2/alpine/Dockerfile
@@ -78,6 +78,7 @@ RUN set -ex \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
 			| sort -u \
+			| grep -v libruby \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \

--- a/2.3/alpine/Dockerfile
+++ b/2.3/alpine/Dockerfile
@@ -78,6 +78,7 @@ RUN set -ex \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
 			| sort -u \
+			| grep -v libruby \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \

--- a/2.4/alpine/Dockerfile
+++ b/2.4/alpine/Dockerfile
@@ -78,6 +78,7 @@ RUN set -ex \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
 			| sort -u \
+			| grep -v libruby \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -78,6 +78,7 @@ RUN set -ex \
 		scanelf --needed --nobanner --recursive /usr/local \
 			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
 			| sort -u \
+			| grep -v libruby \
 			| xargs -r apk info --installed \
 			| sort -u \
 	)" \


### PR DESCRIPTION
Alpine version of ruby image installs unnecessary dependency `ruby-libs`.

```
$ docker container run --rm -ti ruby:2.3-alpine /bin/sh -c 'apk -vv info | grep ruby'
ruby-libs-2.3.1-r0 - Libraries necessary to run Ruby
.ruby-rundeps-0 - virtual meta package
```

```
$ docker container run --rm -ti ruby:2.3-alpine ruby -v
ruby 2.3.4p301 (2017-03-30 revision 58214) [x86_64-linux-musl]
```

Currently the image contains two versions of `libruby.so`: one created during
building process and one installed by `apk`:

```
$ docker container run --rm -ti ruby:2.3-alpine /bin/sh -c 'find . -name libruby.so*'
./usr/lib/libruby.so.2.3
./usr/lib/libruby.so.2.3.0
./usr/local/lib/libruby.so
./usr/local/lib/libruby.so.2.3
./usr/local/lib/libruby.so.2.3.0
```

Ruby uses correct `libruby` version:

```
$ docker container run --rm -ti ruby:2.3-alpine /bin/sh -c 'ldd /usr/local/bin/ruby'
/lib/ld-musl-x86_64.so.1 (0x5651cd9e5000)
libruby.so.2.3 => /usr/local/lib/libruby.so.2.3 (0x7ff147d4c000)
libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x5651cd9e5000)
```

I think we should not install `ruby-libs` from apk.
This commits removes `ruby-libs` from `.ruby-rundeps`.