### PR TITLE
Add explicit multiarch support in "generate-stackbrew-library.sh"

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -33,6 +33,22 @@ dirCommit() {
 	)
 }
 
+getArches() {
+	local repo="$1"; shift
+	local officialImagesUrl='https://github.com/docker-library/official-images/raw/master/library/'
+
+	eval "declare -A -g parentRepoToArches=( $(
+		find -name 'Dockerfile' -exec awk '
+				toupper($1) == "FROM" && $2 !~ /^('"$repo"'|scratch|microsoft\/[^:]+)(:|$)/ {
+					print "'"$officialImagesUrl"'" $2
+				}
+			' '{}' + \
+			| sort -u \
+			| xargs bashbrew cat --format '[{{ .RepoName }}:{{ .TagName }}]="{{ join " " .TagEntry.Architectures }}"'
+	) )"
+}
+getArches 'ruby'
+
 cat <<-EOH
 # this file is generated via https://github.com/docker-library/ruby/blob/$(fileCommit "$self")/$self
 
@@ -51,6 +67,9 @@ join() {
 for version in "${versions[@]}"; do
 	commit="$(dirCommit "$version")"
 
+	parent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/Dockerfile")"
+	arches="${parentRepoToArches[$parent]}"
+
 	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" && $2 == "RUBY_VERSION" { print $3; exit }')"
 
 	versionAliases=(
@@ -62,6 +81,7 @@ for version in "${versions[@]}"; do
 	echo
 	cat <<-EOE
 		Tags: $(join ', ' "${versionAliases[@]}")
+		Architectures: $(join ', ' $arches)
 		GitCommit: $commit
 		Directory: $version
 	EOE
@@ -74,9 +94,18 @@ for version in "${versions[@]}"; do
 		variantAliases=( "${versionAliases[@]/%/-$variant}" )
 		variantAliases=( "${variantAliases[@]//latest-/}" )
 
+		case "$variant" in
+			onbuild) variantArches="$arches" ;;
+			*)
+				variantParent="$(awk 'toupper($1) == "FROM" { print $2 }' "$version/$variant/Dockerfile")"
+				variantArches="${parentRepoToArches[$variantParent]}"
+				;;
+		esac
+
 		echo
 		cat <<-EOE
 			Tags: $(join ', ' "${variantAliases[@]}")
+			Architectures: $(join ', ' $variantArches)
 			GitCommit: $commit
 			Directory: $version/$variant
 		EOE


### PR DESCRIPTION
Still waiting on the [arm32v7 build](https://doi-janky.infosiftr.net/job/multiarch/view/all-images/view/ruby/job/arm32v7/job/ruby/) to complete successfully.

```console
# this file is generated via https://github.com/docker-library/ruby/blob/033381fab0db2f71036bbbaea0580e295d050af7/generate-stackbrew-library.sh

Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
GitRepo: https://github.com/docker-library/ruby.git

Tags: 2.1.10, 2.1
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
Directory: 2.1

Tags: 2.1.10-slim, 2.1-slim
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
Directory: 2.1/slim

Tags: 2.1.10-alpine, 2.1-alpine
Architectures: amd64
GitCommit: c5693b25aa865489fee130e572a3f11bccebd21b
Directory: 2.1/alpine

Tags: 2.1.10-onbuild, 2.1-onbuild
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
Directory: 2.1/onbuild

Tags: 2.2.7, 2.2
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
Directory: 2.2

Tags: 2.2.7-slim, 2.2-slim
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
Directory: 2.2/slim

Tags: 2.2.7-alpine, 2.2-alpine
Architectures: amd64
GitCommit: 82b764e1635acbfcce392d4c0cb6f703a739e173
Directory: 2.2/alpine

Tags: 2.2.7-onbuild, 2.2-onbuild
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 5d04363db6f7ae316ef7056063f020557db828e1
Directory: 2.2/onbuild

Tags: 2.3.4, 2.3
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
Directory: 2.3

Tags: 2.3.4-slim, 2.3-slim
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
Directory: 2.3/slim

Tags: 2.3.4-alpine, 2.3-alpine
Architectures: amd64
GitCommit: 09c6a1602c111cf0cc83bf1df3186a85314ce398
Directory: 2.3/alpine

Tags: 2.3.4-onbuild, 2.3-onbuild
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 1b08f346713a1293c2a9238e470e086126e2e28f
Directory: 2.3/onbuild

Tags: 2.4.1, 2.4, 2, latest
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
Directory: 2.4

Tags: 2.4.1-slim, 2.4-slim, 2-slim, slim
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
Directory: 2.4/slim

Tags: 2.4.1-alpine, 2.4-alpine, 2-alpine, alpine
Architectures: amd64
GitCommit: 21bc2bf9f98aa749f1bd85d190cf0991dac87fc9
Directory: 2.4/alpine

Tags: 2.4.1-onbuild, 2.4-onbuild, 2-onbuild, onbuild
Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 752c5f7cf44870ceae77134b346d20093053c370
Directory: 2.4/onbuild
```

See also docker-library/buildpack-deps#59, docker-library/golang#163, docker-library/docker#63, docker-library/gcc#36, jessfraz/irssi#15, docker-library/redis#95, docker-library/openjdk#121, docker-library/postgres#298, docker-library/haproxy#41, docker-library/httpd#55, https://github.com/docker-library/memcached/pull/19, https://github.com/docker-library/tomcat/pull/73.