### PR TITLE
Adjust scanelf to properly remove "ruby-libs" in the "2.4-alpine3.6" image

### DIFF
--- a/2.2/alpine3.4/Dockerfile
+++ b/2.2/alpine3.4/Dockerfile
@@ -75,11 +75,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
 	&& apk add --virtual .ruby-rundeps $runDeps \
 		bzip2 \

--- a/2.3/alpine3.4/Dockerfile
+++ b/2.3/alpine3.4/Dockerfile
@@ -75,11 +75,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
 	&& apk add --virtual .ruby-rundeps $runDeps \
 		bzip2 \

--- a/2.4/alpine3.4/Dockerfile
+++ b/2.4/alpine3.4/Dockerfile
@@ -75,11 +75,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
 	&& apk add --virtual .ruby-rundeps $runDeps \
 		bzip2 \

--- a/2.4/alpine3.6/Dockerfile
+++ b/2.4/alpine3.6/Dockerfile
@@ -75,11 +75,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
 	&& apk add --virtual .ruby-rundeps $runDeps \
 		bzip2 \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -75,11 +75,10 @@ RUN set -ex \
 	&& make install \
 	\
 	&& runDeps="$( \
-		scanelf --needed --nobanner --recursive /usr/local \
-			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
+			| tr ',' '\n' \
 			| sort -u \
-			| xargs -r apk info --installed \
-			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
 	)" \
 	&& apk add --virtual .ruby-rundeps $runDeps \
 		bzip2 \


### PR DESCRIPTION
This saves ~11MB of final image size (~79.4MB down to ~68.5MB).

Fixes #131