### PR TITLE
Fix build of debian images failing on "gem update --system"

### DIFF
--- a/2.2/jessie/Dockerfile
+++ b/2.2/jessie/Dockerfile
@@ -53,11 +53,10 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION 1.15.4
 

--- a/2.2/jessie/slim/Dockerfile
+++ b/2.2/jessie/slim/Dockerfile
@@ -76,14 +76,13 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& dpkg-query --show --showformat '${package}\n' \
 		| grep -P '^libreadline\d+$' \
 		| xargs apt-mark manual \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION 1.15.4
 

--- a/2.3/jessie/Dockerfile
+++ b/2.3/jessie/Dockerfile
@@ -53,11 +53,10 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION 1.15.4
 

--- a/2.3/jessie/slim/Dockerfile
+++ b/2.3/jessie/slim/Dockerfile
@@ -76,14 +76,13 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& dpkg-query --show --showformat '${package}\n' \
 		| grep -P '^libreadline\d+$' \
 		| xargs apt-mark manual \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION 1.15.4
 

--- a/2.4/jessie/Dockerfile
+++ b/2.4/jessie/Dockerfile
@@ -53,11 +53,10 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION 1.15.4
 

--- a/2.4/jessie/slim/Dockerfile
+++ b/2.4/jessie/slim/Dockerfile
@@ -76,14 +76,13 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& dpkg-query --show --showformat '${package}\n' \
 		| grep -P '^libreadline\d+$' \
 		| xargs apt-mark manual \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION 1.15.4
 

--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -53,11 +53,10 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION 1.15.4
 

--- a/2.4/stretch/slim/Dockerfile
+++ b/2.4/stretch/slim/Dockerfile
@@ -76,14 +76,13 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& dpkg-query --show --showformat '${package}\n' \
 		| grep -P '^libreadline\d+$' \
 		| xargs apt-mark manual \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION 1.15.4
 

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -53,11 +53,10 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION %%BUNDLER%%
 

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -76,14 +76,13 @@ RUN set -ex \
 	&& make -j "$(nproc)" \
 	&& make install \
 	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
 	&& dpkg-query --show --showformat '${package}\n' \
 		| grep -P '^libreadline\d+$' \
 		| xargs apt-mark manual \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
-	&& rm -r /usr/src/ruby \
-	\
-	&& gem update --system "$RUBYGEMS_VERSION"
+	&& rm -r /usr/src/ruby
 
 ENV BUNDLER_VERSION %%BUNDLER%%
 


### PR DESCRIPTION
If we run it later, it fails with:

        gem update --system 2.6.13
        ERROR:  Loading command: update (LoadError)
                cannot load such file -- zlib
        ERROR:  While executing gem ... (NoMethodError)
            undefined method `invoke_with_build_args' for nil:NilClass