### PR TITLE
Replace BUNDLE_BIN with BUNDLE_BIN_DIR

### DIFF
--- a/2.2/alpine3.4/Dockerfile
+++ b/2.2/alpine3.4/Dockerfile
@@ -101,11 +101,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.2/jessie/Dockerfile
+++ b/2.2/jessie/Dockerfile
@@ -66,11 +66,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.2/jessie/slim/Dockerfile
+++ b/2.2/jessie/slim/Dockerfile
@@ -92,11 +92,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.3/alpine3.4/Dockerfile
+++ b/2.3/alpine3.4/Dockerfile
@@ -101,11 +101,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.3/jessie/Dockerfile
+++ b/2.3/jessie/Dockerfile
@@ -66,11 +66,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.3/jessie/slim/Dockerfile
+++ b/2.3/jessie/slim/Dockerfile
@@ -92,11 +92,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.3/stretch/Dockerfile
+++ b/2.3/stretch/Dockerfile
@@ -68,11 +68,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.3/stretch/slim/Dockerfile
+++ b/2.3/stretch/slim/Dockerfile
@@ -92,11 +92,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.4/alpine3.4/Dockerfile
+++ b/2.4/alpine3.4/Dockerfile
@@ -101,11 +101,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.4/alpine3.6/Dockerfile
+++ b/2.4/alpine3.6/Dockerfile
@@ -101,11 +101,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.4/alpine3.7/Dockerfile
+++ b/2.4/alpine3.7/Dockerfile
@@ -101,11 +101,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.4/jessie/Dockerfile
+++ b/2.4/jessie/Dockerfile
@@ -66,11 +66,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.4/jessie/slim/Dockerfile
+++ b/2.4/jessie/slim/Dockerfile
@@ -92,11 +92,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -66,11 +66,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.4/stretch/slim/Dockerfile
+++ b/2.4/stretch/slim/Dockerfile
@@ -92,11 +92,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.5/alpine3.7/Dockerfile
+++ b/2.5/alpine3.7/Dockerfile
@@ -101,11 +101,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.5/stretch/Dockerfile
+++ b/2.5/stretch/Dockerfile
@@ -66,11 +66,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/2.5/stretch/slim/Dockerfile
+++ b/2.5/stretch/slim/Dockerfile
@@ -92,11 +92,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -101,11 +101,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -68,11 +68,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -92,11 +92,11 @@ RUN set -ex \
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
-	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_BIN_DIR="$GEM_HOME/bin" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
-ENV PATH $BUNDLE_BIN:$PATH
-RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
-	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+ENV PATH $BUNDLE_BIN_DIR:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN_DIR" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN_DIR"
 
 CMD [ "irb" ]


### PR DESCRIPTION
By specifying BUNDLE_BIN, bundler will generate binstubs for every gem, which
results in it generating a binstub for itself. The binstub always points to the
same Gemfile, so it is no longer possible to use the bundler on other Gemfiles.

This rename is just to prevent this conflict from occurring.

More info:

[BUNDLE_BIN](https://bundler.io/v1.16/bundle_config.html#LIST-OF-AVAILABLE-KEYS),