### PR TITLE
Allow 2.4 to fallback to alpine latest

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -16,7 +16,6 @@ defaultAlpineVersion='3.7'
 declare -A alpineVersions=(
 	[2.2]='3.4'
 	[2.3]='3.4'
-	[2.4]='3.4'
 )
 
 self="$(basename "$BASH_SOURCE")"


### PR DESCRIPTION
Currently ruby 2.4 has a dockerfile & build for alpine 3.7 (the latest/default version for ruby 2.5). Ruby 2.4 should also be on the latest alpine version!