### PR TITLE
Remove libressl-dev from runtime dependency

### DIFF
--- a/2.3/alpine3.7/Dockerfile
+++ b/2.3/alpine3.7/Dockerfile
@@ -85,7 +85,6 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		libressl-dev \
 		procps \
 		yaml-dev \
 		zlib-dev \

--- a/2.4/alpine3.6/Dockerfile
+++ b/2.4/alpine3.6/Dockerfile
@@ -85,7 +85,6 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		libressl-dev \
 		procps \
 		yaml-dev \
 		zlib-dev \

--- a/2.4/alpine3.7/Dockerfile
+++ b/2.4/alpine3.7/Dockerfile
@@ -85,7 +85,6 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		libressl-dev \
 		procps \
 		yaml-dev \
 		zlib-dev \

--- a/2.5/alpine3.7/Dockerfile
+++ b/2.5/alpine3.7/Dockerfile
@@ -85,7 +85,6 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		libressl-dev \
 		procps \
 		yaml-dev \
 		zlib-dev \

--- a/2.6-rc/alpine3.7/Dockerfile
+++ b/2.6-rc/alpine3.7/Dockerfile
@@ -85,7 +85,6 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		libressl-dev \
 		procps \
 		yaml-dev \
 		zlib-dev \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -85,7 +85,6 @@ RUN set -ex \
 		bzip2 \
 		ca-certificates \
 		libffi-dev \
-		libressl-dev \
 		procps \
 		yaml-dev \
 		zlib-dev \


### PR DESCRIPTION
It seems it isn't runtime dependency because openssl works well without it.

```
$ docker run --rm -it ruby:alpine sh
/ # apk del libressl-dev
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
World updated, but the following packages are not removed due to:
  libressl-dev: .ruby-rundeps

OK: 30 MiB in 31 packages
/ # ruby -r openssl -e 'p OpenSSL::Digest.new("sha256").hexdigest'
"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
```

This PR reduces 15.5MB of the image.

```
$ docker image ls ruby:alpine
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
ruby                alpine              e8e61f5c55cb        4 days ago          62MB
$ docker build . -f 2.5/alpine3.7/Dockerfile -t remove-libressl-dev-from-run-deps
...
$ docker image ls remove-libressl-dev-from-run-deps
REPOSITORY                          TAG                 IMAGE ID            CREATED             SIZE
remove-libressl-dev-from-run-deps   latest              740fcd324fe0        2 minutes ago       46.5MB
```
