### PR TITLE
Apply Alpine thread stack size patch

### DIFF
--- a/2.3/alpine3.7/Dockerfile
+++ b/2.3/alpine3.7/Dockerfile
@@ -55,6 +55,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \

--- a/2.3/alpine3.8/Dockerfile
+++ b/2.3/alpine3.8/Dockerfile
@@ -55,6 +55,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \

--- a/2.4/alpine3.6/Dockerfile
+++ b/2.4/alpine3.6/Dockerfile
@@ -55,6 +55,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \

--- a/2.4/alpine3.7/Dockerfile
+++ b/2.4/alpine3.7/Dockerfile
@@ -55,6 +55,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \

--- a/2.5/alpine3.7/Dockerfile
+++ b/2.5/alpine3.7/Dockerfile
@@ -55,6 +55,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \

--- a/2.6-rc/alpine3.7/Dockerfile
+++ b/2.6-rc/alpine3.7/Dockerfile
@@ -55,6 +55,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \

--- a/2.6-rc/alpine3.8/Dockerfile
+++ b/2.6-rc/alpine3.8/Dockerfile
@@ -55,6 +55,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -55,6 +55,14 @@ RUN set -ex \
 	\
 	&& cd /usr/src/ruby \
 	\
+# https://github.com/docker-library/ruby/issues/196
+# https://bugs.ruby-lang.org/issues/14387#note-13 (patch source)
+# https://bugs.ruby-lang.org/issues/14387#note-16 ("Therefore ncopa's patch looks good for me in general." -- only breaks glibc which doesn't matter here)
+	&& wget -O 'thread-stack-fix.patch' 'https://bugs.ruby-lang.org/attachments/download/7081/0001-thread_pthread.c-make-get_main_stack-portable-on-lin.patch' \
+	&& echo '3ab628a51d92fdf0d2b5835e93564857aea73e0c1de00313864a94a6255cb645 *thread-stack-fix.patch' | sha256sum -c - \
+	&& patch -p1 -i thread-stack-fix.patch \
+	&& rm thread-stack-fix.patch \
+	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	&& { \


### PR DESCRIPTION
This patch was OK'd by a Ruby maintainer (https://bugs.ruby-lang.org/issues/14387#note-16), but hasn't been merged because it isn't generic enough to support glibc properly, which doesn't matter here (since we're Alpine-only in this context).

Closes #196

@ncopa do you see any issue with us applying this patch to all four currently supported versions (2.3, 2.4, 2.5, 2.6-rc)?  The patch applies cleanly, so I was planning to just go for it assuming our basic "does Ruby appear to work properly?" smoke tests pass, but I'd appreciate your thoughts on whether that's safe to do