### PR TITLE
Ubuntu based ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,28 @@ language: bash
 services: docker
 
 env:
+  - VERSION=2.6-rc VARIANT=ubuntu
+  - VERSION=2.6-rc VARIANT=ubuntu/bionic
   - VERSION=2.6-rc VARIANT=stretch
   - VERSION=2.6-rc VARIANT=stretch/slim
   - VERSION=2.6-rc VARIANT=alpine3.8
   - VERSION=2.6-rc VARIANT=alpine3.7
+  - VERSION=2.5 VARIANT=ubuntu
+  - VERSION=2.5 VARIANT=ubuntu/bionic
   - VERSION=2.5 VARIANT=stretch
   - VERSION=2.5 VARIANT=stretch/slim
   - VERSION=2.5 VARIANT=alpine3.8
   - VERSION=2.5 VARIANT=alpine3.7
+  - VERSION=2.4 VARIANT=ubuntu
+  - VERSION=2.4 VARIANT=ubuntu/bionic
   - VERSION=2.4 VARIANT=stretch
   - VERSION=2.4 VARIANT=stretch/slim
   - VERSION=2.4 VARIANT=jessie
   - VERSION=2.4 VARIANT=jessie/slim
   - VERSION=2.4 VARIANT=alpine3.8
   - VERSION=2.4 VARIANT=alpine3.7
+  - VERSION=2.3 VARIANT=ubuntu
+  - VERSION=2.3 VARIANT=ubuntu/bionic
   - VERSION=2.3 VARIANT=stretch
   - VERSION=2.3 VARIANT=stretch/slim
   - VERSION=2.3 VARIANT=jessie

--- a/2.3/ubuntu/Dockerfile
+++ b/2.3/ubuntu/Dockerfile
@@ -61,7 +61,7 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
 	\
 	&& mkdir -p /usr/src/ruby \

--- a/2.3/ubuntu/Dockerfile
+++ b/2.3/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.3/ubuntu/Dockerfile
+++ b/2.3/ubuntu/Dockerfile
@@ -1,0 +1,116 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		ca-certificates \
+		curl \
+		g++ \
+		gawk \
+		gcc \
+		git \
+		libffi-dev \
+		libreadline7 \
+		libssl-dev \
+		libtool \
+		libyaml-0-2 \
+		libyaml-dev \
+		procps \
+		ruby-psych \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.3
+ENV RUBY_VERSION 2.3.8
+ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
+ENV RUBYGEMS_VERSION 2.7.8
+ENV BUNDLER_VERSION 1.17.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		apt-utils \
+		autoconf \
+		automake \
+		bison \
+		libc6-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+		pkg-config \
+		sqlite3 \
+		wget \
+		' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]
+
+

--- a/2.3/ubuntu/Dockerfile
+++ b/2.3/ubuntu/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 		gawk \
 		gcc \
 		git \
+                libgdbm5 \
 		libffi-dev \
 		libreadline7 \
 		libssl-dev \

--- a/2.3/ubuntu/bionic/Dockerfile
+++ b/2.3/ubuntu/bionic/Dockerfile
@@ -61,7 +61,7 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
 	\
 	&& mkdir -p /usr/src/ruby \

--- a/2.3/ubuntu/bionic/Dockerfile
+++ b/2.3/ubuntu/bionic/Dockerfile
@@ -1,0 +1,116 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		ca-certificates \
+		curl \
+		g++ \
+		gawk \
+		gcc \
+		git \
+		libffi-dev \
+		libreadline7 \
+		libssl-dev \
+		libtool \
+		libyaml-0-2 \
+		libyaml-dev \
+		procps \
+		ruby-psych \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.3
+ENV RUBY_VERSION 2.3.8
+ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
+ENV RUBYGEMS_VERSION 2.7.8
+ENV BUNDLER_VERSION 1.17.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		apt-utils \
+		autoconf \
+		automake \
+		bison \
+		libc6-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+		pkg-config \
+		sqlite3 \
+		wget \
+		' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]
+
+

--- a/2.3/ubuntu/bionic/Dockerfile
+++ b/2.3/ubuntu/bionic/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 		gawk \
 		gcc \
 		git \
+                libgdbm5 \
 		libffi-dev \
 		libreadline7 \
 		libssl-dev \

--- a/2.4/ubuntu/Dockerfile
+++ b/2.4/ubuntu/Dockerfile
@@ -61,7 +61,7 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
 	\
 	&& mkdir -p /usr/src/ruby \

--- a/2.4/ubuntu/Dockerfile
+++ b/2.4/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.4/ubuntu/Dockerfile
+++ b/2.4/ubuntu/Dockerfile
@@ -1,0 +1,116 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		ca-certificates \
+		curl \
+		g++ \
+		gawk \
+		gcc \
+		git \
+		libffi-dev \
+		libreadline7 \
+		libssl-dev \
+		libtool \
+		libyaml-0-2 \
+		libyaml-dev \
+		procps \
+		ruby-psych \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.4
+ENV RUBY_VERSION 2.4.5
+ENV RUBY_DOWNLOAD_SHA256 2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb
+ENV RUBYGEMS_VERSION 2.7.8
+ENV BUNDLER_VERSION 1.17.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		apt-utils \
+		autoconf \
+		automake \
+		bison \
+		libc6-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+		pkg-config \
+		sqlite3 \
+		wget \
+		' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]
+
+

--- a/2.4/ubuntu/Dockerfile
+++ b/2.4/ubuntu/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 		gawk \
 		gcc \
 		git \
+                libgdbm5 \
 		libffi-dev \
 		libreadline7 \
 		libssl-dev \

--- a/2.4/ubuntu/bionic/Dockerfile
+++ b/2.4/ubuntu/bionic/Dockerfile
@@ -61,7 +61,7 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
 	\
 	&& mkdir -p /usr/src/ruby \

--- a/2.4/ubuntu/bionic/Dockerfile
+++ b/2.4/ubuntu/bionic/Dockerfile
@@ -1,0 +1,116 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		ca-certificates \
+		curl \
+		g++ \
+		gawk \
+		gcc \
+		git \
+		libffi-dev \
+		libreadline7 \
+		libssl-dev \
+		libtool \
+		libyaml-0-2 \
+		libyaml-dev \
+		procps \
+		ruby-psych \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.4
+ENV RUBY_VERSION 2.4.5
+ENV RUBY_DOWNLOAD_SHA256 2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb
+ENV RUBYGEMS_VERSION 2.7.8
+ENV BUNDLER_VERSION 1.17.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		apt-utils \
+		autoconf \
+		automake \
+		bison \
+		libc6-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+		pkg-config \
+		sqlite3 \
+		wget \
+		' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]
+
+

--- a/2.4/ubuntu/bionic/Dockerfile
+++ b/2.4/ubuntu/bionic/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 		gawk \
 		gcc \
 		git \
+                libgdbm5 \
 		libffi-dev \
 		libreadline7 \
 		libssl-dev \

--- a/2.5/ubuntu/Dockerfile
+++ b/2.5/ubuntu/Dockerfile
@@ -61,7 +61,7 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
 	\
 	&& mkdir -p /usr/src/ruby \

--- a/2.5/ubuntu/Dockerfile
+++ b/2.5/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.5/ubuntu/Dockerfile
+++ b/2.5/ubuntu/Dockerfile
@@ -1,0 +1,116 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		ca-certificates \
+		curl \
+		g++ \
+		gawk \
+		gcc \
+		git \
+		libffi-dev \
+		libreadline7 \
+		libssl-dev \
+		libtool \
+		libyaml-0-2 \
+		libyaml-dev \
+		procps \
+		ruby-psych \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.5
+ENV RUBY_VERSION 2.5.3
+ENV RUBY_DOWNLOAD_SHA256 1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
+ENV RUBYGEMS_VERSION 2.7.8
+ENV BUNDLER_VERSION 1.17.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		apt-utils \
+		autoconf \
+		automake \
+		bison \
+		libc6-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+		pkg-config \
+		sqlite3 \
+		wget \
+		' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]
+
+

--- a/2.5/ubuntu/Dockerfile
+++ b/2.5/ubuntu/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 		gawk \
 		gcc \
 		git \
+                libgdbm5 \
 		libffi-dev \
 		libreadline7 \
 		libssl-dev \

--- a/2.5/ubuntu/bionic/Dockerfile
+++ b/2.5/ubuntu/bionic/Dockerfile
@@ -61,7 +61,7 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
 	\
 	&& mkdir -p /usr/src/ruby \

--- a/2.5/ubuntu/bionic/Dockerfile
+++ b/2.5/ubuntu/bionic/Dockerfile
@@ -1,0 +1,116 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		ca-certificates \
+		curl \
+		g++ \
+		gawk \
+		gcc \
+		git \
+		libffi-dev \
+		libreadline7 \
+		libssl-dev \
+		libtool \
+		libyaml-0-2 \
+		libyaml-dev \
+		procps \
+		ruby-psych \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.5
+ENV RUBY_VERSION 2.5.3
+ENV RUBY_DOWNLOAD_SHA256 1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
+ENV RUBYGEMS_VERSION 2.7.8
+ENV BUNDLER_VERSION 1.17.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		apt-utils \
+		autoconf \
+		automake \
+		bison \
+		libc6-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+		pkg-config \
+		sqlite3 \
+		wget \
+		' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]
+
+

--- a/2.5/ubuntu/bionic/Dockerfile
+++ b/2.5/ubuntu/bionic/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 		gawk \
 		gcc \
 		git \
+                libgdbm5 \
 		libffi-dev \
 		libreadline7 \
 		libssl-dev \

--- a/2.6-rc/ubuntu/Dockerfile
+++ b/2.6-rc/ubuntu/Dockerfile
@@ -61,7 +61,7 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
 	\
 	&& mkdir -p /usr/src/ruby \

--- a/2.6-rc/ubuntu/Dockerfile
+++ b/2.6-rc/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:latest
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.6-rc/ubuntu/Dockerfile
+++ b/2.6-rc/ubuntu/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 		gawk \
 		gcc \
 		git \
+                libgdbm5 \
 		libffi-dev \
 		libreadline7 \
 		libssl-dev \

--- a/2.6-rc/ubuntu/Dockerfile
+++ b/2.6-rc/ubuntu/Dockerfile
@@ -1,0 +1,116 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		ca-certificates \
+		curl \
+		g++ \
+		gawk \
+		gcc \
+		git \
+		libffi-dev \
+		libreadline7 \
+		libssl-dev \
+		libtool \
+		libyaml-0-2 \
+		libyaml-dev \
+		procps \
+		ruby-psych \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.6-rc
+ENV RUBY_VERSION 2.6.0-preview3
+ENV RUBY_DOWNLOAD_SHA256 9856d9e0e32df9e5cdf01928eec363d037f1a76dab2abbf828170647beaf64fe
+ENV RUBYGEMS_VERSION 2.7.8
+ENV BUNDLER_VERSION 1.17.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		apt-utils \
+		autoconf \
+		automake \
+		bison \
+		libc6-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+		pkg-config \
+		sqlite3 \
+		wget \
+		' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]
+
+

--- a/2.6-rc/ubuntu/bionic/Dockerfile
+++ b/2.6-rc/ubuntu/bionic/Dockerfile
@@ -61,7 +61,7 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
 	\
 	&& mkdir -p /usr/src/ruby \

--- a/2.6-rc/ubuntu/bionic/Dockerfile
+++ b/2.6-rc/ubuntu/bionic/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
 		gawk \
 		gcc \
 		git \
+                libgdbm5 \
 		libffi-dev \
 		libreadline7 \
 		libssl-dev \

--- a/2.6-rc/ubuntu/bionic/Dockerfile
+++ b/2.6-rc/ubuntu/bionic/Dockerfile
@@ -1,0 +1,116 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		ca-certificates \
+		curl \
+		g++ \
+		gawk \
+		gcc \
+		git \
+		libffi-dev \
+		libreadline7 \
+		libssl-dev \
+		libtool \
+		libyaml-0-2 \
+		libyaml-dev \
+		procps \
+		ruby-psych \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR 2.6-rc
+ENV RUBY_VERSION 2.6.0-preview3
+ENV RUBY_DOWNLOAD_SHA256 9856d9e0e32df9e5cdf01928eec363d037f1a76dab2abbf828170647beaf64fe
+ENV RUBYGEMS_VERSION 2.7.8
+ENV BUNDLER_VERSION 1.17.1
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		apt-utils \
+		autoconf \
+		automake \
+		bison \
+		libc6-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+		pkg-config \
+		sqlite3 \
+		wget \
+		' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]
+
+

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -61,7 +61,7 @@ RUN set -ex \
 	&& apt-get install -y --no-install-recommends $buildDeps \
 	&& rm -rf /var/lib/apt/lists/* \
 	\
-	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
 	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
 	\
 	&& mkdir -p /usr/src/ruby \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -10,6 +10,7 @@ RUN apt-get update \
 		gawk \
 		gcc \
 		git \
+                libgdbm5 \
 		libffi-dev \
 		libreadline7 \
 		libssl-dev \

--- a/Dockerfile-ubuntu.template
+++ b/Dockerfile-ubuntu.template
@@ -1,0 +1,116 @@
+FROM ubuntu:%%PLACEHOLDER%%
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		ca-certificates \
+		curl \
+		g++ \
+		gawk \
+		gcc \
+		git \
+		libffi-dev \
+		libreadline7 \
+		libssl-dev \
+		libtool \
+		libyaml-0-2 \
+		libyaml-dev \
+		procps \
+		ruby-psych \
+		zlib1g-dev \
+	&& rm -rf /var/lib/apt/lists/*
+
+# skip installing gem documentation
+RUN mkdir -p /usr/local/etc \
+	&& { \
+		echo 'install: --no-document'; \
+		echo 'update: --no-document'; \
+	} >> /usr/local/etc/gemrc
+
+ENV RUBY_MAJOR %%VERSION%%
+ENV RUBY_VERSION %%FULL_VERSION%%
+ENV RUBY_DOWNLOAD_SHA256 %%SHA256%%
+ENV RUBYGEMS_VERSION %%RUBYGEMS%%
+ENV BUNDLER_VERSION %%BUNDLER%%
+
+# some of ruby's build scripts are written in ruby
+#   we purge system ruby later to make sure our final image uses what we just built
+RUN set -ex \
+	\
+	&& buildDeps=' \
+		apt-utils \
+		autoconf \
+		automake \
+		bison \
+		libc6-dev \
+		libffi-dev \
+		libgdbm-dev \
+		libgmp-dev \
+		libcurl4-openssl-dev \
+		libncurses5-dev \
+		libreadline-dev \
+		libsqlite3-dev \
+		make \
+		patch \
+		pkg-config \
+		sqlite3 \
+		wget \
+		' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& rm -rf /var/lib/apt/lists/* \
+	\
+	&& wget --no-check-certificate -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz" \
+	&& echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum -c - \
+	\
+	&& mkdir -p /usr/src/ruby \
+	&& tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1 \
+	&& rm ruby.tar.xz \
+	\
+	&& cd /usr/src/ruby \
+	\
+# hack in "ENABLE_PATH_CHECK" disabling to suppress:
+#   warning: Insecure world writable dir
+	&& { \
+		echo '#define ENABLE_PATH_CHECK 0'; \
+		echo; \
+		cat file.c; \
+	} > file.c.new \
+	&& mv file.c.new file.c \
+	\
+	&& autoconf \
+	&& gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)" \
+	&& ./configure \
+		--build="$gnuArch" \
+		--disable-install-doc \
+		--enable-shared \
+	&& make -j "$(nproc)" \
+	&& make install \
+	\
+	&& dpkg-query --show --showformat '${package}\n' \
+		| grep -P '^libreadline\d+$' \
+		| xargs apt-mark manual \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& cd / \
+	&& rm -r /usr/src/ruby \
+	\
+	&& gem update --system "$RUBYGEMS_VERSION" \
+	&& gem install bundler --version "$BUNDLER_VERSION" --force \
+	&& rm -r /root/.gem/
+
+# install things globally, for great justice
+# and don't create ".bundle" in all our apps
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+# path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438
+ENV PATH $GEM_HOME/bin:$BUNDLE_PATH/gems/bin:$PATH
+# adjust permissions of a few directories for running "gem install" as an arbitrary user
+RUN mkdir -p "$GEM_HOME" && chmod 777 "$GEM_HOME"
+# (BUNDLE_PATH = GEM_HOME, no need to mkdir/chown both)
+
+CMD [ "irb" ]
+
+

--- a/update.sh
+++ b/update.sh
@@ -79,7 +79,8 @@ for version in "${versions[@]}"; do
 		case "$variant" in
 			slim|windowsservercore) template="$variant"; tag="$(basename "$(dirname "$dir")")" ;;
 			alpine*) template='alpine'; tag="${variant#alpine}" ;;
-			ubuntu|bionic) template='ubuntu'; tag="${variant#ubuntu}"; os_version='18.04' ;;
+			ubuntu) template='ubuntu'; tag="${variant#ubuntu}"; os_version='latest' ;;
+			bionic) template='ubuntu'; tag="${variant#ubuntu}"; os_version='18.04' ;;
 			*) template='debian'; tag="$variant" ;;
 		esac
 


### PR DESCRIPTION
Ubuntu now provides minimal images on dockerhub
https://blog.ubuntu.com/2018/07/09/minimal-ubuntu-released
https://hub.docker.com/_/ubuntu/
Many rubyists would prefer to use ubuntu as the base platform for ruby.
Initial support for dockerized ruby running on ubuntu.

Signed-off-by: S.Cavallo <smcavallo@hotmail.com>