### PR TITLE
fixed rubygems and bundler version for ruby2.6rc

### DIFF
--- a/2.6-rc/alpine3.7/Dockerfile
+++ b/2.6-rc/alpine3.7/Dockerfile
@@ -10,8 +10,8 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.6-rc
 ENV RUBY_VERSION 2.6.0-rc1
 ENV RUBY_DOWNLOAD_SHA256 21d9d54c20e45ccacecf8bea4dfccd05edc52479c776381ae98ef6a7b4afa739
-ENV RUBYGEMS_VERSION 2.7.8
-ENV BUNDLER_VERSION 1.17.1
+ENV RUBYGEMS_VERSION 3.0.0.beta3
+ENV BUNDLER_VERSION 2.0.0.pre.2
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.6-rc/alpine3.8/Dockerfile
+++ b/2.6-rc/alpine3.8/Dockerfile
@@ -11,7 +11,7 @@ ENV RUBY_MAJOR 2.6-rc
 ENV RUBY_VERSION 2.6.0-rc1
 ENV RUBY_DOWNLOAD_SHA256 21d9d54c20e45ccacecf8bea4dfccd05edc52479c776381ae98ef6a7b4afa739
 ENV RUBYGEMS_VERSION 2.7.8
-ENV BUNDLER_VERSION 1.17.1
+ENV BUNDLER_VERSION 2.0.0.pre.2
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.6-rc/stretch/Dockerfile
+++ b/2.6-rc/stretch/Dockerfile
@@ -10,8 +10,8 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.6-rc
 ENV RUBY_VERSION 2.6.0-rc1
 ENV RUBY_DOWNLOAD_SHA256 21d9d54c20e45ccacecf8bea4dfccd05edc52479c776381ae98ef6a7b4afa739
-ENV RUBYGEMS_VERSION 2.7.8
-ENV BUNDLER_VERSION 1.17.1
+ENV RUBYGEMS_VERSION 3.0.0.beta3
+ENV BUNDLER_VERSION 2.0.0.pre.2
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.6-rc/stretch/slim/Dockerfile
+++ b/2.6-rc/stretch/slim/Dockerfile
@@ -22,8 +22,8 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.6-rc
 ENV RUBY_VERSION 2.6.0-rc1
 ENV RUBY_DOWNLOAD_SHA256 21d9d54c20e45ccacecf8bea4dfccd05edc52479c776381ae98ef6a7b4afa739
-ENV RUBYGEMS_VERSION 2.7.8
-ENV BUNDLER_VERSION 1.17.1
+ENV RUBYGEMS_VERSION 3.0.0.beta3
+ENV BUNDLER_VERSION 2.0.0.pre.2
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built


### PR DESCRIPTION
Bundled psych has some imcopatible changes, so it should run with rubygems 3.0.0.beta3 and bundler 2.0.0.pre2.

bundled rubygems version is [3.0.0.beta3](https://github.com/ruby/ruby/blob/v2_6_0_rc1/lib/rubygems.rb#L12)

bundled bundler version is [2.0.0.pre2](https://github.com/ruby/ruby/blob/v2_6_0_rc1/lib/bundler/version.rb#L10)