### PR TITLE
Adjust "slim" variants to use "slim" Debian bases

### DIFF
--- a/2.3/jessie/slim/Dockerfile
+++ b/2.3/jessie/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:jessie-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.3/stretch/slim/Dockerfile
+++ b/2.3/stretch/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.4/jessie/slim/Dockerfile
+++ b/2.4/jessie/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:jessie-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.4/stretch/slim/Dockerfile
+++ b/2.4/stretch/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.5/stretch/slim/Dockerfile
+++ b/2.5/stretch/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/2.6/stretch/slim/Dockerfile
+++ b/2.6/stretch/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-slim
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \

--- a/update.sh
+++ b/update.sh
@@ -85,6 +85,10 @@ for version in "${versions[@]}"; do
 		esac
 		template="Dockerfile-${template}.template"
 
+		if [ "$variant" = 'slim' ]; then
+			tag+='-slim'
+		fi
+
 		sed -r \
 			-e 's!%%VERSION%%!'"$version"'!g' \
 			-e 's!%%FULL_VERSION%%!'"$fullVersion"'!g' \


### PR DESCRIPTION
This saves ~50MB in my testing (2.6 went from ~175MB down to ~125MB and 2.3 went from ~250MB down to ~200MB).

Closes #256