### PR TITLE
Add libgmp for faster biginteger calculations.

### DIFF
--- a/2.3/jessie/Dockerfile
+++ b/2.3/jessie/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
 		bison \
 		dpkg-dev \
 		libgdbm-dev \
+		libgmp3-dev \
 		ruby \
 	' \
 	&& apt-get update \

--- a/2.3/stretch/Dockerfile
+++ b/2.3/stretch/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
 		bison \
 		dpkg-dev \
 		libgdbm-dev \
+		libgmp3-dev \
 		# ruby 2.3 on stretch can only support libssl1.0-dev (libssl dev from buildpack-deps is 1.1.x)
 		libssl1.0-dev \
 		ruby \

--- a/2.4/jessie/Dockerfile
+++ b/2.4/jessie/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
 		bison \
 		dpkg-dev \
 		libgdbm-dev \
+		libgmp3-dev \
 		ruby \
 	' \
 	&& apt-get update \

--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
 		bison \
 		dpkg-dev \
 		libgdbm-dev \
+		libgmp3-dev \
 		ruby \
 	' \
 	&& apt-get update \

--- a/2.5/stretch/Dockerfile
+++ b/2.5/stretch/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
 		bison \
 		dpkg-dev \
 		libgdbm-dev \
+		libgmp3-dev \
 		ruby \
 	' \
 	&& apt-get update \

--- a/2.6/stretch/Dockerfile
+++ b/2.6/stretch/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
 		bison \
 		dpkg-dev \
 		libgdbm-dev \
+		libgmp3-dev \
 		ruby \
 	' \
 	&& apt-get update \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -20,6 +20,7 @@ RUN set -ex \
 		bison \
 		dpkg-dev \
 		libgdbm-dev \
+		libgmp3-dev \
 		# ruby 2.3 on stretch can only support libssl1.0-dev (libssl dev from buildpack-deps is 1.1.x)
 		libssl1.0-dev \
 		ruby \


### PR DESCRIPTION
I was wondering why some large integer multiplications were taking a while, so I ran
```
$ docker run ruby:2.6 ruby -e 'puts Integer::GMP_VERSION'
-e:1:in `<main>': uninitialized constant Integer::GMP_VERSION (NameError)
```
and found that GMP wasn't included in the default images. Building these images gives me
```
$ docker run ruby:gmp-2.6 ruby -e 'puts Integer::GMP_VERSION'
GMP 6.1.2
```