### PR TITLE
Add "libgmp-dev" and "gmp-dev" persistently

### DIFF
--- a/2.3/alpine3.7/Dockerfile
+++ b/2.3/alpine3.7/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.7
 
+RUN apk add --no-cache \
+		gmp-dev
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -28,7 +31,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \

--- a/2.3/alpine3.8/Dockerfile
+++ b/2.3/alpine3.8/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.8
 
+RUN apk add --no-cache \
+		gmp-dev
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -28,7 +31,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \

--- a/2.3/jessie/slim/Dockerfile
+++ b/2.3/jessie/slim/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
 		ca-certificates \
 		libffi-dev \
 		libgdbm3 \
+		libgmp-dev \
 		libssl-dev \
 		libyaml-dev \
 		procps \
@@ -37,7 +38,6 @@ RUN set -ex \
 		libbz2-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libxml2-dev \

--- a/2.3/stretch/slim/Dockerfile
+++ b/2.3/stretch/slim/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
 		ca-certificates \
 		libffi-dev \
 		libgdbm3 \
+		libgmp-dev \
 		libssl1.0-dev \
 		libyaml-dev \
 		procps \
@@ -37,7 +38,6 @@ RUN set -ex \
 		libbz2-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libxml2-dev \

--- a/2.4/alpine3.8/Dockerfile
+++ b/2.4/alpine3.8/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.8
 
+RUN apk add --no-cache \
+		gmp-dev
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -28,7 +31,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \

--- a/2.4/alpine3.9/Dockerfile
+++ b/2.4/alpine3.9/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.9
 
+RUN apk add --no-cache \
+		gmp-dev
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -28,7 +31,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \

--- a/2.4/jessie/slim/Dockerfile
+++ b/2.4/jessie/slim/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
 		ca-certificates \
 		libffi-dev \
 		libgdbm3 \
+		libgmp-dev \
 		libssl-dev \
 		libyaml-dev \
 		procps \
@@ -37,7 +38,6 @@ RUN set -ex \
 		libbz2-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libxml2-dev \

--- a/2.4/stretch/slim/Dockerfile
+++ b/2.4/stretch/slim/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
 		ca-certificates \
 		libffi-dev \
 		libgdbm3 \
+		libgmp-dev \
 		libssl-dev \
 		libyaml-dev \
 		procps \
@@ -37,7 +38,6 @@ RUN set -ex \
 		libbz2-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libxml2-dev \

--- a/2.5/alpine3.8/Dockerfile
+++ b/2.5/alpine3.8/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.8
 
+RUN apk add --no-cache \
+		gmp-dev
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -28,7 +31,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \

--- a/2.5/alpine3.9/Dockerfile
+++ b/2.5/alpine3.9/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.9
 
+RUN apk add --no-cache \
+		gmp-dev
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -28,7 +31,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \

--- a/2.5/stretch/slim/Dockerfile
+++ b/2.5/stretch/slim/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
 		ca-certificates \
 		libffi-dev \
 		libgdbm3 \
+		libgmp-dev \
 		libssl-dev \
 		libyaml-dev \
 		procps \
@@ -37,7 +38,6 @@ RUN set -ex \
 		libbz2-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libxml2-dev \

--- a/2.6/alpine3.8/Dockerfile
+++ b/2.6/alpine3.8/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.8
 
+RUN apk add --no-cache \
+		gmp-dev
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -27,7 +30,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \

--- a/2.6/alpine3.9/Dockerfile
+++ b/2.6/alpine3.9/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.9
 
+RUN apk add --no-cache \
+		gmp-dev
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -27,7 +30,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \

--- a/2.6/stretch/slim/Dockerfile
+++ b/2.6/stretch/slim/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update \
 		ca-certificates \
 		libffi-dev \
 		libgdbm3 \
+		libgmp-dev \
 		libssl-dev \
 		libyaml-dev \
 		procps \
@@ -36,7 +37,6 @@ RUN set -ex \
 		libbz2-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libxml2-dev \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -1,5 +1,8 @@
 FROM alpine:%%PLACEHOLDER%%
 
+RUN apk add --no-cache \
+		gmp-dev
+
 # skip installing gem documentation
 RUN mkdir -p /usr/local/etc \
 	&& { \
@@ -28,7 +31,6 @@ RUN set -ex \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -6,6 +6,7 @@ RUN apt-get update \
 		ca-certificates \
 		libffi-dev \
 		libgdbm3 \
+		libgmp-dev \
 		libssl-dev \
 		libyaml-dev \
 		procps \
@@ -37,7 +38,6 @@ RUN set -ex \
 		libbz2-dev \
 		libgdbm-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
 		libxml2-dev \


### PR DESCRIPTION
Closes #267 (follow-up to #266)

It turns out that if Ruby is compiled with `libgmp` available, it needs to be available for linking when building native extensions too.