### PR TITLE
Bump RubyGems version for CVE fixes

### DIFF
--- a/2.3/alpine3.7/Dockerfile
+++ b/2.3/alpine3.7/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.3
 ENV RUBY_VERSION 2.3.8
 ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.3/alpine3.8/Dockerfile
+++ b/2.3/alpine3.8/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.3
 ENV RUBY_VERSION 2.3.8
 ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.3/jessie/Dockerfile
+++ b/2.3/jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.3
 ENV RUBY_VERSION 2.3.8
 ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.3/jessie/slim/Dockerfile
+++ b/2.3/jessie/slim/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.3
 ENV RUBY_VERSION 2.3.8
 ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.3/stretch/Dockerfile
+++ b/2.3/stretch/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.3
 ENV RUBY_VERSION 2.3.8
 ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.3/stretch/slim/Dockerfile
+++ b/2.3/stretch/slim/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.3
 ENV RUBY_VERSION 2.3.8
 ENV RUBY_DOWNLOAD_SHA256 910f635d84fd0d81ac9bdee0731279e6026cb4cd1315bbbb5dfb22e09c5c1dfe
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.4/alpine3.8/Dockerfile
+++ b/2.4/alpine3.8/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.4
 ENV RUBY_VERSION 2.4.5
 ENV RUBY_DOWNLOAD_SHA256 2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.4/alpine3.9/Dockerfile
+++ b/2.4/alpine3.9/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.4
 ENV RUBY_VERSION 2.4.5
 ENV RUBY_DOWNLOAD_SHA256 2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.4/jessie/Dockerfile
+++ b/2.4/jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.4
 ENV RUBY_VERSION 2.4.5
 ENV RUBY_DOWNLOAD_SHA256 2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.4/jessie/slim/Dockerfile
+++ b/2.4/jessie/slim/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.4
 ENV RUBY_VERSION 2.4.5
 ENV RUBY_DOWNLOAD_SHA256 2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.4
 ENV RUBY_VERSION 2.4.5
 ENV RUBY_DOWNLOAD_SHA256 2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.4/stretch/slim/Dockerfile
+++ b/2.4/stretch/slim/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.4
 ENV RUBY_VERSION 2.4.5
 ENV RUBY_DOWNLOAD_SHA256 2f0cdcce9989f63ef7c2939bdb17b1ef244c4f384d85b8531d60e73d8cc31eeb
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.5/alpine3.8/Dockerfile
+++ b/2.5/alpine3.8/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.3
 ENV RUBY_DOWNLOAD_SHA256 1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.5/alpine3.9/Dockerfile
+++ b/2.5/alpine3.9/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.3
 ENV RUBY_DOWNLOAD_SHA256 1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.5/stretch/Dockerfile
+++ b/2.5/stretch/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.3
 ENV RUBY_DOWNLOAD_SHA256 1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.5/stretch/slim/Dockerfile
+++ b/2.5/stretch/slim/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.3
 ENV RUBY_DOWNLOAD_SHA256 1cc9d0359a8ea35fc6111ec830d12e60168f3b9b305a3c2578357d360fcf306f
-ENV RUBYGEMS_VERSION 3.0.1
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/2.6/alpine3.8/Dockerfile
+++ b/2.6/alpine3.8/Dockerfile
@@ -13,6 +13,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.1
 ENV RUBY_DOWNLOAD_SHA256 47b629808e9fd44ce1f760cdf3ed14875fc9b19d4f334e82e2cf25cb2898f2f2
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -100,6 +101,9 @@ RUN set -ex \
 	&& apk del --no-network .ruby-builddeps \
 	&& cd / \
 	&& rm -r /usr/src/ruby \
+# make sure bundled "rubygems" is older than RUBYGEMS_VERSION (https://github.com/docker-library/ruby/issues/246)
+	&& ruby -e 'exit(Gem::Version.create(ENV["RUBYGEMS_VERSION"]) > Gem::Version.create(Gem::VERSION))' \
+	&& gem update --system "$RUBYGEMS_VERSION" && rm -r /root/.gem/ \
 # rough smoke test
 	&& ruby --version && gem --version && bundle --version
 

--- a/2.6/alpine3.9/Dockerfile
+++ b/2.6/alpine3.9/Dockerfile
@@ -13,6 +13,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.1
 ENV RUBY_DOWNLOAD_SHA256 47b629808e9fd44ce1f760cdf3ed14875fc9b19d4f334e82e2cf25cb2898f2f2
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -100,6 +101,9 @@ RUN set -ex \
 	&& apk del --no-network .ruby-builddeps \
 	&& cd / \
 	&& rm -r /usr/src/ruby \
+# make sure bundled "rubygems" is older than RUBYGEMS_VERSION (https://github.com/docker-library/ruby/issues/246)
+	&& ruby -e 'exit(Gem::Version.create(ENV["RUBYGEMS_VERSION"]) > Gem::Version.create(Gem::VERSION))' \
+	&& gem update --system "$RUBYGEMS_VERSION" && rm -r /root/.gem/ \
 # rough smoke test
 	&& ruby --version && gem --version && bundle --version
 

--- a/2.6/stretch/Dockerfile
+++ b/2.6/stretch/Dockerfile
@@ -10,6 +10,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.1
 ENV RUBY_DOWNLOAD_SHA256 47b629808e9fd44ce1f760cdf3ed14875fc9b19d4f334e82e2cf25cb2898f2f2
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -55,6 +56,9 @@ RUN set -ex \
 	&& apt-get purge -y --auto-remove $buildDeps \
 	&& cd / \
 	&& rm -r /usr/src/ruby \
+# make sure bundled "rubygems" is older than RUBYGEMS_VERSION (https://github.com/docker-library/ruby/issues/246)
+	&& ruby -e 'exit(Gem::Version.create(ENV["RUBYGEMS_VERSION"]) > Gem::Version.create(Gem::VERSION))' \
+	&& gem update --system "$RUBYGEMS_VERSION" && rm -r /root/.gem/ \
 # rough smoke test
 	&& ruby --version && gem --version && bundle --version
 

--- a/2.6/stretch/slim/Dockerfile
+++ b/2.6/stretch/slim/Dockerfile
@@ -23,6 +23,7 @@ RUN mkdir -p /usr/local/etc \
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.1
 ENV RUBY_DOWNLOAD_SHA256 47b629808e9fd44ce1f760cdf3ed14875fc9b19d4f334e82e2cf25cb2898f2f2
+ENV RUBYGEMS_VERSION 3.0.3
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -87,6 +88,9 @@ RUN set -ex \
 	\
 	&& cd / \
 	&& rm -r /usr/src/ruby \
+# make sure bundled "rubygems" is older than RUBYGEMS_VERSION (https://github.com/docker-library/ruby/issues/246)
+	&& ruby -e 'exit(Gem::Version.create(ENV["RUBYGEMS_VERSION"]) > Gem::Version.create(Gem::VERSION))' \
+	&& gem update --system "$RUBYGEMS_VERSION" && rm -r /root/.gem/ \
 # rough smoke test
 	&& ruby --version && gem --version && bundle --version
 

--- a/update.sh
+++ b/update.sh
@@ -18,7 +18,7 @@ latest_gem_version() {
 }
 
 # https://github.com/docker-library/ruby/issues/246
-rubygems='3.0.1'
+rubygems='3.0.3'
 declare -A newEnoughRubygems=(
 	[2.6]=1 # 3.0.1+
 )

--- a/update.sh
+++ b/update.sh
@@ -20,7 +20,7 @@ latest_gem_version() {
 # https://github.com/docker-library/ruby/issues/246
 rubygems='3.0.3'
 declare -A newEnoughRubygems=(
-	[2.6]=1 # 3.0.1+
+#	[2.6]=1 # 2.6.1 => gems 3.0.1
 )
 # TODO once all versions are in this family of "new enough", remove RUBYGEMS_VERSION code entirely
 


### PR DESCRIPTION
> There have been a number of CVEs for vulnerabilities in Rubygems announced today https://www.ruby-lang.org/en/news/2019/03/05/multiple-vulnerabilities-in-rubygems/.

From the discussion on #255, I have only updated RubyGems on versions of Ruby that we install an explicit version of RubyGems newer than is bundled with the Ruby release. What this means is that 2.6 still has RubyGems 3.0.1 because I am assuming that a bugfix release is incoming (given the following comment):
> In that case, you should be fine sticking with just the latest Ruby patch release. Anytime there is a CVE in RubyGems, the Ruby team issues a new bugfix release for Ruby with the patch for that issue. ￼:+1:
> \- https://github.com/docker-library/ruby/pull/255#issuecomment-451012334

:point_up:If this is not the case, please let us know so we can also bump the gems version for the 2.6 images.

CC @indirect and @deivid-rodriguez, do you have any insight as to whether or not Ruby will be making a new release for this set of RubyGems CVEs?

Related: https://bugs.ruby-lang.org/issues/15637 (it looks like that are patches being backported for updating Ruby 2.6 to RubyGems 3.0.3)

Fixes #270