### PR TITLE
Prefer `BUNDLE_PATH__SYSTEM=true`

### DIFF
--- a/2.4/alpine3.10/Dockerfile
+++ b/2.4/alpine3.10/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/alpine3.9/Dockerfile
+++ b/2.4/alpine3.9/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/jessie/Dockerfile
+++ b/2.4/jessie/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/jessie/slim/Dockerfile
+++ b/2.4/jessie/slim/Dockerfile
@@ -108,7 +108,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/stretch/slim/Dockerfile
+++ b/2.4/stretch/slim/Dockerfile
@@ -108,7 +108,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.5/alpine3.10/Dockerfile
+++ b/2.5/alpine3.10/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.5/alpine3.9/Dockerfile
+++ b/2.5/alpine3.9/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.5/stretch/Dockerfile
+++ b/2.5/stretch/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.5/stretch/slim/Dockerfile
+++ b/2.5/stretch/slim/Dockerfile
@@ -108,7 +108,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.6/alpine3.10/Dockerfile
+++ b/2.6/alpine3.10/Dockerfile
@@ -120,7 +120,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.6/alpine3.9/Dockerfile
+++ b/2.6/alpine3.9/Dockerfile
@@ -120,7 +120,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.6/stretch/Dockerfile
+++ b/2.6/stretch/Dockerfile
@@ -79,7 +79,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.6/stretch/slim/Dockerfile
+++ b/2.6/stretch/slim/Dockerfile
@@ -104,7 +104,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.7-rc/alpine3.10/Dockerfile
+++ b/2.7-rc/alpine3.10/Dockerfile
@@ -120,7 +120,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.7-rc/buster/Dockerfile
+++ b/2.7-rc/buster/Dockerfile
@@ -79,7 +79,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.7-rc/buster/slim/Dockerfile
+++ b/2.7-rc/buster/slim/Dockerfile
@@ -105,7 +105,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
 	{ \
-		echo 'install: --no-document'; \
+	echo 'install: --no-document'; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -83,7 +83,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -109,7 +109,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH="$GEM_HOME" \
+ENV BUNDLE_PATH__SYSTEM=true \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438


### PR DESCRIPTION
Bundler has a special configuration to be used when you want to use the global rubygems path to install gems.

Using this option makes no difference currently with respect to `BUNDLE_PATH=$GEM_HOME` but in the future bundler will append the ruby scope to `$BUNDLE_PATH`. It actually does that already when the installation path is specified via configuration (`bundle config path /usr/local/bundle`) or via command line flag (`bundle install --path /usr/local/bundle`), but due to a bug it doesn't do it when specified via the environment (`BUNDLE_PATH=/usr/local/bundle`), like in the official docker images.

This means that in future versions of bundler (where the bug is fixed), `BUNDLE_PATH=$GEM_HOME` will actually install gems to `$GEM_HOME/ruby/2.7.0`, for example. Setting `BUNDLE_PATH__SYSTEM=true` specifically avoids that and installs them to `$GEM_HOME` as expected here.

Reference: https://github.com/bundler/bundler/issues/7197.