### PR TITLE
Revert "Prefer `BUNDLE_PATH__SYSTEM=true`"

### DIFF
--- a/2.4/alpine3.10/Dockerfile
+++ b/2.4/alpine3.10/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/alpine3.9/Dockerfile
+++ b/2.4/alpine3.9/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/buster/Dockerfile
+++ b/2.4/buster/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/buster/slim/Dockerfile
+++ b/2.4/buster/slim/Dockerfile
@@ -109,7 +109,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/stretch/Dockerfile
+++ b/2.4/stretch/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.4/stretch/slim/Dockerfile
+++ b/2.4/stretch/slim/Dockerfile
@@ -108,7 +108,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.5/alpine3.10/Dockerfile
+++ b/2.5/alpine3.10/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.5/alpine3.9/Dockerfile
+++ b/2.5/alpine3.9/Dockerfile
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.5/stretch/Dockerfile
+++ b/2.5/stretch/Dockerfile
@@ -83,7 +83,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.5/stretch/slim/Dockerfile
+++ b/2.5/stretch/slim/Dockerfile
@@ -108,7 +108,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.6/alpine3.10/Dockerfile
+++ b/2.6/alpine3.10/Dockerfile
@@ -120,7 +120,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.6/alpine3.9/Dockerfile
+++ b/2.6/alpine3.9/Dockerfile
@@ -120,7 +120,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.6/stretch/Dockerfile
+++ b/2.6/stretch/Dockerfile
@@ -79,7 +79,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.6/stretch/slim/Dockerfile
+++ b/2.6/stretch/slim/Dockerfile
@@ -104,7 +104,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.7-rc/alpine3.10/Dockerfile
+++ b/2.7-rc/alpine3.10/Dockerfile
@@ -120,7 +120,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.7-rc/buster/Dockerfile
+++ b/2.7-rc/buster/Dockerfile
@@ -79,7 +79,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/2.7-rc/buster/slim/Dockerfile
+++ b/2.7-rc/buster/slim/Dockerfile
@@ -105,7 +105,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -124,7 +124,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -83,7 +83,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -109,7 +109,7 @@ RUN set -eux; \
 # install things globally, for great justice
 # and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
-ENV BUNDLE_PATH__SYSTEM=true \
+ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_SILENCE_ROOT_WARNING=1 \
 	BUNDLE_APP_CONFIG="$GEM_HOME"
 # path recommendation: https://github.com/bundler/bundler/pull/6469#issuecomment-383235438


### PR DESCRIPTION
This reverts commit e040029c82501556371e9d84a9db607dfb1bba51.

The change has created some problems with the `--deployment` flag. I'm working on fixing those issues, but they will take time to propagate, so I think it's better to revert my changes for the moment.

The problem is related to incompatibilities between `BUNDLE_PATH` and `BUNDLE_PATH__SYSTEM` that @tianon somehow suspected in https://github.com/docker-library/ruby/pull/285#issuecomment-506516000, but that my basic smoke tests failed to detect.

I'm really sorry for the trouble, specially knowing that propagating changes to the actual Docker images is tricky (PR here, PR to official images repo...) and we now have to go through the whole process again :pray:.

Fixes #288.