### PR TITLE
Set LANG by default

### DIFF
--- a/2.5/alpine3.11/Dockerfile
+++ b/2.5/alpine3.11/Dockerfile
@@ -11,6 +11,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.8
 ENV RUBY_DOWNLOAD_SHA256 0391b2ffad3133e274469f9953ebfd0c9f7c186238968cbdeeb0651aa02a4d6d

--- a/2.5/alpine3.12/Dockerfile
+++ b/2.5/alpine3.12/Dockerfile
@@ -11,6 +11,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.8
 ENV RUBY_DOWNLOAD_SHA256 0391b2ffad3133e274469f9953ebfd0c9f7c186238968cbdeeb0651aa02a4d6d

--- a/2.5/buster/Dockerfile
+++ b/2.5/buster/Dockerfile
@@ -8,6 +8,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.8
 ENV RUBY_DOWNLOAD_SHA256 0391b2ffad3133e274469f9953ebfd0c9f7c186238968cbdeeb0651aa02a4d6d

--- a/2.5/buster/slim/Dockerfile
+++ b/2.5/buster/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.8
 ENV RUBY_DOWNLOAD_SHA256 0391b2ffad3133e274469f9953ebfd0c9f7c186238968cbdeeb0651aa02a4d6d

--- a/2.5/stretch/Dockerfile
+++ b/2.5/stretch/Dockerfile
@@ -8,6 +8,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.8
 ENV RUBY_DOWNLOAD_SHA256 0391b2ffad3133e274469f9953ebfd0c9f7c186238968cbdeeb0651aa02a4d6d

--- a/2.5/stretch/slim/Dockerfile
+++ b/2.5/stretch/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.5
 ENV RUBY_VERSION 2.5.8
 ENV RUBY_DOWNLOAD_SHA256 0391b2ffad3133e274469f9953ebfd0c9f7c186238968cbdeeb0651aa02a4d6d

--- a/2.6/alpine3.11/Dockerfile
+++ b/2.6/alpine3.11/Dockerfile
@@ -11,6 +11,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.6
 ENV RUBY_DOWNLOAD_SHA256 5db187882b7ac34016cd48d7032e197f07e4968f406b0690e20193b9b424841f

--- a/2.6/alpine3.12/Dockerfile
+++ b/2.6/alpine3.12/Dockerfile
@@ -11,6 +11,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.6
 ENV RUBY_DOWNLOAD_SHA256 5db187882b7ac34016cd48d7032e197f07e4968f406b0690e20193b9b424841f

--- a/2.6/buster/Dockerfile
+++ b/2.6/buster/Dockerfile
@@ -8,6 +8,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.6
 ENV RUBY_DOWNLOAD_SHA256 5db187882b7ac34016cd48d7032e197f07e4968f406b0690e20193b9b424841f

--- a/2.6/buster/slim/Dockerfile
+++ b/2.6/buster/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.6
 ENV RUBY_DOWNLOAD_SHA256 5db187882b7ac34016cd48d7032e197f07e4968f406b0690e20193b9b424841f

--- a/2.6/stretch/Dockerfile
+++ b/2.6/stretch/Dockerfile
@@ -8,6 +8,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.6
 ENV RUBY_DOWNLOAD_SHA256 5db187882b7ac34016cd48d7032e197f07e4968f406b0690e20193b9b424841f

--- a/2.6/stretch/slim/Dockerfile
+++ b/2.6/stretch/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.6
 ENV RUBY_VERSION 2.6.6
 ENV RUBY_DOWNLOAD_SHA256 5db187882b7ac34016cd48d7032e197f07e4968f406b0690e20193b9b424841f

--- a/2.7/alpine3.11/Dockerfile
+++ b/2.7/alpine3.11/Dockerfile
@@ -11,6 +11,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.7
 ENV RUBY_VERSION 2.7.1
 ENV RUBY_DOWNLOAD_SHA256 b224f9844646cc92765df8288a46838511c1cec5b550d8874bd4686a904fcee7

--- a/2.7/alpine3.12/Dockerfile
+++ b/2.7/alpine3.12/Dockerfile
@@ -11,6 +11,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.7
 ENV RUBY_VERSION 2.7.1
 ENV RUBY_DOWNLOAD_SHA256 b224f9844646cc92765df8288a46838511c1cec5b550d8874bd4686a904fcee7

--- a/2.7/buster/Dockerfile
+++ b/2.7/buster/Dockerfile
@@ -8,6 +8,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.7
 ENV RUBY_VERSION 2.7.1
 ENV RUBY_DOWNLOAD_SHA256 b224f9844646cc92765df8288a46838511c1cec5b550d8874bd4686a904fcee7

--- a/2.7/buster/slim/Dockerfile
+++ b/2.7/buster/slim/Dockerfile
@@ -22,6 +22,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR 2.7
 ENV RUBY_VERSION 2.7.1
 ENV RUBY_DOWNLOAD_SHA256 b224f9844646cc92765df8288a46838511c1cec5b550d8874bd4686a904fcee7

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -11,6 +11,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR %%VERSION%%
 ENV RUBY_VERSION %%FULL_VERSION%%
 ENV RUBY_DOWNLOAD_SHA256 %%SHA256%%

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -8,6 +8,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR %%VERSION%%
 ENV RUBY_VERSION %%FULL_VERSION%%
 ENV RUBY_DOWNLOAD_SHA256 %%SHA256%%

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -22,6 +22,7 @@ RUN set -eux; \
 		echo 'update: --no-document'; \
 	} >> /usr/local/etc/gemrc
 
+ENV LANG C.UTF-8
 ENV RUBY_MAJOR %%VERSION%%
 ENV RUBY_VERSION %%FULL_VERSION%%
 ENV RUBY_DOWNLOAD_SHA256 %%SHA256%%


### PR DESCRIPTION
Ruby docker images officially provided by ruby-lang.org set `LANG` as `C.UTF-8` by default.

https://hub.docker.com/r/rubylang/ruby/

https://github.com/ruby/ruby-docker-images/blob/36c5d8b68eb91e34825500e50ca677f5574401f7/Dockerfile#L3

https://github.com/docker-library/ruby/issues/45#issuecomment-117298344

> I'd rather see something more official from either Ruby or Rails upstreams
> recommending a UTF-8 locale by default than just the anecdote that it's
> "more common" or "more convenient".

I think it's the one so we should set it by default.