### PR TITLE
Update generate-stackbrew-library.sh for Ruby 3.0

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,8 +2,8 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	[2.8-rc]='rc'
-	[2.7]='2 latest'
+	[3.0]='3 latest'
+	[2.7]='2'
 )
 
 defaultDebianSuite='buster'


### PR DESCRIPTION
Follow up https://github.com/docker-library/ruby/pull/332

<details>
<summary> $ ./generate-stackbrew-library.sh  </summary>


```
# this file is generated via https://github.com/docker-library/ruby/blob/f5aa18521c3b73f92ae340d14dc9d24555d02f43/generate-stackbrew-library.sh

Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
GitRepo: https://github.com/docker-library/ruby.git

Tags: 3.0.0-buster, 3.0-buster, 3-buster, buster, 3.0.0, 3.0, 3, latest
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
GitCommit: 921f2e68671461785e822aa437b68433278263b9
Directory: 3.0/buster

Tags: 3.0.0-slim-buster, 3.0-slim-buster, 3-slim-buster, slim-buster, 3.0.0-slim, 3.0-slim, 3-slim, slim
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
GitCommit: 921f2e68671461785e822aa437b68433278263b9
Directory: 3.0/buster/slim

Tags: 3.0.0-alpine3.12, 3.0-alpine3.12, 3-alpine3.12, alpine3.12, 3.0.0-alpine, 3.0-alpine, 3-alpine, alpine
Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 921f2e68671461785e822aa437b68433278263b9
Directory: 3.0/alpine3.12

Tags: 2.7.2-buster, 2.7-buster, 2-buster, 2.7.2, 2.7, 2
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
Directory: 2.7/buster

Tags: 2.7.2-slim-buster, 2.7-slim-buster, 2-slim-buster, 2.7.2-slim, 2.7-slim, 2-slim
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
Directory: 2.7/buster/slim

Tags: 2.7.2-alpine3.12, 2.7-alpine3.12, 2-alpine3.12, 2.7.2-alpine, 2.7-alpine, 2-alpine
Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
Directory: 2.7/alpine3.12

Tags: 2.7.2-alpine3.11, 2.7-alpine3.11, 2-alpine3.11
Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
Directory: 2.7/alpine3.11

Tags: 2.6.6-buster, 2.6-buster, 2.6.6, 2.6
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.6/buster

Tags: 2.6.6-slim-buster, 2.6-slim-buster, 2.6.6-slim, 2.6-slim
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.6/buster/slim

Tags: 2.6.6-stretch, 2.6-stretch
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.6/stretch

Tags: 2.6.6-slim-stretch, 2.6-slim-stretch
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.6/stretch/slim

Tags: 2.6.6-alpine3.12, 2.6-alpine3.12, 2.6.6-alpine, 2.6-alpine
Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.6/alpine3.12

Tags: 2.6.6-alpine3.11, 2.6-alpine3.11
Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.6/alpine3.11

Tags: 2.5.8-buster, 2.5-buster, 2.5.8, 2.5
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.5/buster

Tags: 2.5.8-slim-buster, 2.5-slim-buster, 2.5.8-slim, 2.5-slim
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.5/buster/slim

Tags: 2.5.8-stretch, 2.5-stretch
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.5/stretch

Tags: 2.5.8-slim-stretch, 2.5-slim-stretch
Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.5/stretch/slim

Tags: 2.5.8-alpine3.12, 2.5-alpine3.12, 2.5.8-alpine, 2.5-alpine
Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.5/alpine3.12

Tags: 2.5.8-alpine3.11, 2.5-alpine3.11
Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
GitCommit: 8e49e25b591d4cfa6324b6dada4f16629a1e51ce
Directory: 2.5/alpine3.11
```

</details>