### PR TITLE
Add `bullseye` & `bullseye-slim` versions

### DIFF
--- a/2.6/bullseye/Dockerfile
+++ b/2.6/bullseye/Dockerfile
@@ -4,21 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:stretch-slim
-
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		bzip2 \
-		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM buildpack-deps:bullseye
 
 # skip installing gem documentation
 RUN set -eux; \
@@ -44,18 +30,6 @@ RUN set -eux; \
 		dpkg-dev \
 		libgdbm-dev \
 		ruby \
-		autoconf \
-		g++ \
-		gcc \
-		libbz2-dev \
-		libglib2.0-dev \
-		libncurses-dev \
-		libreadline-dev \
-		libxml2-dev \
-		libxslt-dev \
-		make \
-		wget \
-		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/2.6/slim-bullseye/Dockerfile
+++ b/2.6/slim-bullseye/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN set -eux; \
 	apt-get update; \

--- a/2.7/bullseye/Dockerfile
+++ b/2.7/bullseye/Dockerfile
@@ -4,21 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:buster-slim
-
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		bzip2 \
-		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM buildpack-deps:bullseye
 
 # skip installing gem documentation
 RUN set -eux; \
@@ -29,9 +15,9 @@ RUN set -eux; \
 	} >> /usr/local/etc/gemrc
 
 ENV LANG C.UTF-8
-ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.8
-ENV RUBY_DOWNLOAD_SHA256 8262e4663169c85787fdc9bfbd04d9eb86eb2a4b56d7f98373a8fcaa18e593eb
+ENV RUBY_MAJOR 2.7
+ENV RUBY_VERSION 2.7.4
+ENV RUBY_DOWNLOAD_SHA256 2a80824e0ad6100826b69b9890bf55cfc4cf2b61a1e1330fccbcb30c46cef8d7
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -44,19 +30,6 @@ RUN set -eux; \
 		dpkg-dev \
 		libgdbm-dev \
 		ruby \
-		autoconf \
-		g++ \
-		gcc \
-		libbz2-dev \
-		libgdbm-compat-dev \
-		libglib2.0-dev \
-		libncurses-dev \
-		libreadline-dev \
-		libxml2-dev \
-		libxslt-dev \
-		make \
-		wget \
-		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/2.7/slim-bullseye/Dockerfile
+++ b/2.7/slim-bullseye/Dockerfile
@@ -4,7 +4,21 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM buildpack-deps:stretch
+FROM debian:bullseye-slim
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		bzip2 \
+		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 # skip installing gem documentation
 RUN set -eux; \
@@ -15,9 +29,9 @@ RUN set -eux; \
 	} >> /usr/local/etc/gemrc
 
 ENV LANG C.UTF-8
-ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.8
-ENV RUBY_DOWNLOAD_SHA256 8262e4663169c85787fdc9bfbd04d9eb86eb2a4b56d7f98373a8fcaa18e593eb
+ENV RUBY_MAJOR 2.7
+ENV RUBY_VERSION 2.7.4
+ENV RUBY_DOWNLOAD_SHA256 2a80824e0ad6100826b69b9890bf55cfc4cf2b61a1e1330fccbcb30c46cef8d7
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -30,6 +44,19 @@ RUN set -eux; \
 		dpkg-dev \
 		libgdbm-dev \
 		ruby \
+		autoconf \
+		g++ \
+		gcc \
+		libbz2-dev \
+		libgdbm-compat-dev \
+		libglib2.0-dev \
+		libncurses-dev \
+		libreadline-dev \
+		libxml2-dev \
+		libxslt-dev \
+		make \
+		wget \
+		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/2.7/slim-buster/Dockerfile
+++ b/2.7/slim-buster/Dockerfile
@@ -48,6 +48,7 @@ RUN set -eux; \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libgdbm-compat-dev \
 		libglib2.0-dev \
 		libncurses-dev \
 		libreadline-dev \
@@ -56,8 +57,6 @@ RUN set -eux; \
 		make \
 		wget \
 		xz-utils \
-# https://packages.debian.org/sid/libgdbm-compat-dev (needed for "dbm" core module, but only in Buster+)
-		libgdbm-compat-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.0/bullseye/Dockerfile
+++ b/3.0/bullseye/Dockerfile
@@ -4,21 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:buster-slim
-
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		bzip2 \
-		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM buildpack-deps:bullseye
 
 # skip installing gem documentation
 RUN set -eux; \
@@ -29,9 +15,9 @@ RUN set -eux; \
 	} >> /usr/local/etc/gemrc
 
 ENV LANG C.UTF-8
-ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.8
-ENV RUBY_DOWNLOAD_SHA256 8262e4663169c85787fdc9bfbd04d9eb86eb2a4b56d7f98373a8fcaa18e593eb
+ENV RUBY_MAJOR 3.0
+ENV RUBY_VERSION 3.0.2
+ENV RUBY_DOWNLOAD_SHA256 570e7773100f625599575f363831166d91d49a1ab97d3ab6495af44774155c40
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -44,19 +30,6 @@ RUN set -eux; \
 		dpkg-dev \
 		libgdbm-dev \
 		ruby \
-		autoconf \
-		g++ \
-		gcc \
-		libbz2-dev \
-		libgdbm-compat-dev \
-		libglib2.0-dev \
-		libncurses-dev \
-		libreadline-dev \
-		libxml2-dev \
-		libxslt-dev \
-		make \
-		wget \
-		xz-utils \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.0/slim-bullseye/Dockerfile
+++ b/3.0/slim-bullseye/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 RUN set -eux; \
 	apt-get update; \
@@ -29,9 +29,9 @@ RUN set -eux; \
 	} >> /usr/local/etc/gemrc
 
 ENV LANG C.UTF-8
-ENV RUBY_MAJOR 2.6
-ENV RUBY_VERSION 2.6.8
-ENV RUBY_DOWNLOAD_SHA256 8262e4663169c85787fdc9bfbd04d9eb86eb2a4b56d7f98373a8fcaa18e593eb
+ENV RUBY_MAJOR 3.0
+ENV RUBY_VERSION 3.0.2
+ENV RUBY_DOWNLOAD_SHA256 570e7773100f625599575f363831166d91d49a1ab97d3ab6495af44774155c40
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built

--- a/3.0/slim-buster/Dockerfile
+++ b/3.0/slim-buster/Dockerfile
@@ -48,6 +48,7 @@ RUN set -eux; \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libgdbm-compat-dev \
 		libglib2.0-dev \
 		libncurses-dev \
 		libreadline-dev \
@@ -56,8 +57,6 @@ RUN set -eux; \
 		make \
 		wget \
 		xz-utils \
-# https://packages.debian.org/sid/libgdbm-compat-dev (needed for "dbm" core module, but only in Buster+)
-		libgdbm-compat-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -103,6 +103,7 @@ RUN set -eux; \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libgdbm-compat-dev \
 		libglib2.0-dev \
 		libncurses-dev \
 		libreadline-dev \
@@ -111,10 +112,6 @@ RUN set -eux; \
 		make \
 		wget \
 		xz-utils \
-{{ if env.variant | endswith("stretch") then "" else ( -}}
-# https://packages.debian.org/sid/libgdbm-compat-dev (needed for "dbm" core module, but only in Buster+)
-		libgdbm-compat-dev \
-{{ ) end -}}
 {{ ) else "" end -}}
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/versions.json
+++ b/versions.json
@@ -2,10 +2,10 @@
   "2.6": {
     "sha256": "8262e4663169c85787fdc9bfbd04d9eb86eb2a4b56d7f98373a8fcaa18e593eb",
     "variants": [
+      "bullseye",
+      "slim-bullseye",
       "buster",
       "slim-buster",
-      "stretch",
-      "slim-stretch",
       "alpine3.14",
       "alpine3.13"
     ],
@@ -14,6 +14,8 @@
   "2.7": {
     "sha256": "2a80824e0ad6100826b69b9890bf55cfc4cf2b61a1e1330fccbcb30c46cef8d7",
     "variants": [
+      "bullseye",
+      "slim-bullseye",
       "buster",
       "slim-buster",
       "alpine3.14",
@@ -24,6 +26,8 @@
   "3.0": {
     "sha256": "570e7773100f625599575f363831166d91d49a1ab97d3ab6495af44774155c40",
     "variants": [
+      "bullseye",
+      "slim-bullseye",
       "buster",
       "slim-buster",
       "alpine3.14",

--- a/versions.sh
+++ b/versions.sh
@@ -68,10 +68,8 @@ for version in "${versions[@]}"; do
 			sha256: env.shaVal,
 			variants: [
 				(
-					"buster",
-					if env.rcVersion == "2.6" then
-						"stretch"
-					else empty end
+					"bullseye",
+					"buster"
 				| ., "slim-" + .), # https://github.com/docker-library/ruby/pull/142#issuecomment-320012893
 				(
 					"3.14",


### PR DESCRIPTION
[bullseye is out](https://www.debian.org/News/2021/20210814), let's add it.

Closes #356