### PR TITLE
Use libucontext in 2.7 to fix alpine based builds on arm32v6/7 and s390x

### DIFF
--- a/2.6/alpine3.13/Dockerfile
+++ b/2.6/alpine3.13/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/2.6/alpine3.14/Dockerfile
+++ b/2.6/alpine3.14/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/2.7/alpine3.13/Dockerfile
+++ b/2.7/alpine3.13/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -97,6 +98,7 @@ RUN set -eux; \
 	\
 	autoconf; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	export LIBS='-lucontext'; \
 	./configure \
 		--build="$gnuArch" \
 		--disable-install-doc \

--- a/2.7/alpine3.14/Dockerfile
+++ b/2.7/alpine3.14/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -97,6 +98,7 @@ RUN set -eux; \
 	\
 	autoconf; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	export LIBS='-lucontext'; \
 	./configure \
 		--build="$gnuArch" \
 		--disable-install-doc \

--- a/3.0/alpine3.13/Dockerfile
+++ b/3.0/alpine3.13/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/3.0/alpine3.14/Dockerfile
+++ b/3.0/alpine3.14/Dockerfile
@@ -51,6 +51,7 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -76,6 +76,7 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -165,6 +166,9 @@ RUN set -eux; \
 	\
 	autoconf; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+{{ if is_alpine and env.version == "2.7" then ( -}}
+	export LIBS='-lucontext'; \
+{{ ) else "" end -}}
 	./configure \
 		--build="$gnuArch" \
 		--disable-install-doc \


### PR DESCRIPTION
Alpine also [uses `ucontext` on all arches](https://git.alpinelinux.org/aports/commit/main/ruby/APKBUILD?h=3.14-stable&id=5ed0f177e21cb9582f05a4088209ada9b143ef80) for their Ruby 2.7.