### PR TITLE
Limit ucontext linking to arm32* and s390x arches

### DIFF
--- a/2.6/alpine3.13/Dockerfile
+++ b/2.6/alpine3.13/Dockerfile
@@ -51,7 +51,6 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/2.6/alpine3.14/Dockerfile
+++ b/2.6/alpine3.14/Dockerfile
@@ -51,7 +51,6 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \

--- a/2.7/alpine3.13/Dockerfile
+++ b/2.7/alpine3.13/Dockerfile
@@ -51,7 +51,6 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -97,8 +96,16 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# fix builds on arm32v6/7 and s390x: https://github.com/docker-library/ruby/issues/308
+	# and don't break the other arches: https://github.com/docker-library/ruby/issues/365
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		s390x | armhf | armv7) \
+			apk add --no-cache libucontext-dev; \
+			export LIBS='-lucontext'; \
+			;; \
+	esac; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
-	export LIBS='-lucontext'; \
 	./configure \
 		--build="$gnuArch" \
 		--disable-install-doc \

--- a/2.7/alpine3.14/Dockerfile
+++ b/2.7/alpine3.14/Dockerfile
@@ -51,7 +51,6 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -97,8 +96,16 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# fix builds on arm32v6/7 and s390x: https://github.com/docker-library/ruby/issues/308
+	# and don't break the other arches: https://github.com/docker-library/ruby/issues/365
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		s390x | armhf | armv7) \
+			apk add --no-cache libucontext-dev; \
+			export LIBS='-lucontext'; \
+			;; \
+	esac; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
-	export LIBS='-lucontext'; \
 	./configure \
 		--build="$gnuArch" \
 		--disable-install-doc \

--- a/3.0/alpine3.13/Dockerfile
+++ b/3.0/alpine3.13/Dockerfile
@@ -51,7 +51,6 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -97,6 +96,15 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# fix builds on arm32v6/7 and s390x: https://github.com/docker-library/ruby/issues/308
+	# and don't break the other arches: https://github.com/docker-library/ruby/issues/365
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		s390x | armhf | armv7) \
+			apk add --no-cache libucontext-dev; \
+			export LIBS='-lucontext'; \
+			;; \
+	esac; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.0/alpine3.14/Dockerfile
+++ b/3.0/alpine3.14/Dockerfile
@@ -51,7 +51,6 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -97,6 +96,15 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# fix builds on arm32v6/7 and s390x: https://github.com/docker-library/ruby/issues/308
+	# and don't break the other arches: https://github.com/docker-library/ruby/issues/365
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		s390x | armhf | armv7) \
+			apk add --no-cache libucontext-dev; \
+			export LIBS='-lucontext'; \
+			;; \
+	esac; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -76,7 +76,6 @@ RUN set -eux; \
 		libffi-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libucontext-dev \
 		linux-headers \
 		make \
 		ncurses-dev \
@@ -165,10 +164,18 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
-	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
-{{ if is_alpine and env.version == "2.7" then ( -}}
-	export LIBS='-lucontext'; \
+{{ if is_alpine and ( [ "2.7", "3.0" ] | index(env.version) ) then ( -}}
+	# fix builds on arm32v6/7 and s390x: https://github.com/docker-library/ruby/issues/308
+	# and don't break the other arches: https://github.com/docker-library/ruby/issues/365
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		s390x | armhf | armv7) \
+			apk add --no-cache libucontext-dev; \
+			export LIBS='-lucontext'; \
+			;; \
+	esac; \
 {{ ) else "" end -}}
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \
 		--disable-install-doc \


### PR DESCRIPTION
And keep `libucontext-dev` on those arches to ensure rubygems work. (~249kb)

Fixes #365