### PR TITLE
Add Debian sid to support YJIT on Ruby 3.2

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,10 +5,13 @@
 	def is_slim:
 		env.variant | startswith("slim-")
 	;
+	def is_sid:
+		env.variant | startswith("sid")
+	;
 	def should_yjit:
 		# https://github.com/docker-library/ruby/issues/390
 		([ "2.7", "3.0", "3.1" ] | index(env.version) | not)
-		and is_alpine
+		and is_alpine or is_sid
 -}}
 {{ if is_alpine then ( -}}
 FROM alpine:{{ env.variant | ltrimstr("alpine") }}
@@ -113,6 +116,9 @@ RUN set -eux; \
 		dpkg-dev \
 		libgdbm-dev \
 		ruby \
+{{ if should_yjit then ( -}}
+		rustc \
+{{ ) else "" end -}}
 {{ if is_slim then ( -}}
 		autoconf \
 		g++ \

--- a/versions.json
+++ b/versions.json
@@ -41,7 +41,8 @@
       "buster",
       "slim-buster",
       "alpine3.17",
-      "alpine3.16"
+      "alpine3.16",
+      "sid"
     ],
     "version": "3.2.0-rc1"
   }


### PR DESCRIPTION
Inspired by #390 I wanted to take a stab at trying to add YJIT to Debian-based images. The sid upgrade was required to get a version of rustc newer than 1.58.1.

I've validated the YJIT working by building and running the sid Ruby build and executing:
```
root@f95b728b4716:/# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux bookworm/sid"
...
root@f95b728b4716:/# RUBY_YJIT_ENABLE=1 irb
irb(main):001:0> RubyVM::YJIT.enabled?
=> true
```