### PR TITLE
Remove unnecessary readline headers in 3.3+

### DIFF
--- a/3.0/alpine3.16/Dockerfile
+++ b/3.0/alpine3.16/Dockerfile
@@ -34,7 +34,6 @@ ENV RUBY_DOWNLOAD_SHA256 b5cbee93e62d85cfb2a408c49fa30a74231ae8409c2b3858e5f5ea2
 #   we purge system ruby later to make sure our final image uses what we just built
 RUN set -eux; \
 	\
-# readline-dev vs libedit-dev: https://bugs.ruby-lang.org/issues/11869 and https://github.com/docker-library/ruby/issues/75
 	apk add --no-cache --virtual .ruby-builddeps \
 		autoconf \
 		bison \

--- a/3.1/alpine3.17/Dockerfile
+++ b/3.1/alpine3.17/Dockerfile
@@ -34,7 +34,6 @@ ENV RUBY_DOWNLOAD_SHA256 1b6d6010e76036c937b9671f4752f065aeca800a6c664f71f6c9a69
 #   we purge system ruby later to make sure our final image uses what we just built
 RUN set -eux; \
 	\
-# readline-dev vs libedit-dev: https://bugs.ruby-lang.org/issues/11869 and https://github.com/docker-library/ruby/issues/75
 	apk add --no-cache --virtual .ruby-builddeps \
 		autoconf \
 		bison \

--- a/3.1/alpine3.18/Dockerfile
+++ b/3.1/alpine3.18/Dockerfile
@@ -34,7 +34,6 @@ ENV RUBY_DOWNLOAD_SHA256 1b6d6010e76036c937b9671f4752f065aeca800a6c664f71f6c9a69
 #   we purge system ruby later to make sure our final image uses what we just built
 RUN set -eux; \
 	\
-# readline-dev vs libedit-dev: https://bugs.ruby-lang.org/issues/11869 and https://github.com/docker-library/ruby/issues/75
 	apk add --no-cache --virtual .ruby-builddeps \
 		autoconf \
 		bison \

--- a/3.2/alpine3.17/Dockerfile
+++ b/3.2/alpine3.17/Dockerfile
@@ -34,7 +34,6 @@ ENV RUBY_DOWNLOAD_SHA256 4b352d0f7ec384e332e3e44cdbfdcd5ff2d594af3c8296b5636c710
 #   we purge system ruby later to make sure our final image uses what we just built
 RUN set -eux; \
 	\
-# readline-dev vs libedit-dev: https://bugs.ruby-lang.org/issues/11869 and https://github.com/docker-library/ruby/issues/75
 	apk add --no-cache --virtual .ruby-builddeps \
 		autoconf \
 		bison \

--- a/3.2/alpine3.18/Dockerfile
+++ b/3.2/alpine3.18/Dockerfile
@@ -34,7 +34,6 @@ ENV RUBY_DOWNLOAD_SHA256 4b352d0f7ec384e332e3e44cdbfdcd5ff2d594af3c8296b5636c710
 #   we purge system ruby later to make sure our final image uses what we just built
 RUN set -eux; \
 	\
-# readline-dev vs libedit-dev: https://bugs.ruby-lang.org/issues/11869 and https://github.com/docker-library/ruby/issues/75
 	apk add --no-cache --virtual .ruby-builddeps \
 		autoconf \
 		bison \

--- a/3.3-rc/alpine3.17/Dockerfile
+++ b/3.3-rc/alpine3.17/Dockerfile
@@ -34,7 +34,6 @@ ENV RUBY_DOWNLOAD_SHA256 ae300b49e06c13087dd163b97eddd38db895dc8e0c9904284119795
 #   we purge system ruby later to make sure our final image uses what we just built
 RUN set -eux; \
 	\
-# readline-dev vs libedit-dev: https://bugs.ruby-lang.org/issues/11869 and https://github.com/docker-library/ruby/issues/75
 	apk add --no-cache --virtual .ruby-builddeps \
 		autoconf \
 		bison \
@@ -58,7 +57,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		readline-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.3-rc/alpine3.18/Dockerfile
+++ b/3.3-rc/alpine3.18/Dockerfile
@@ -34,7 +34,6 @@ ENV RUBY_DOWNLOAD_SHA256 ae300b49e06c13087dd163b97eddd38db895dc8e0c9904284119795
 #   we purge system ruby later to make sure our final image uses what we just built
 RUN set -eux; \
 	\
-# readline-dev vs libedit-dev: https://bugs.ruby-lang.org/issues/11869 and https://github.com/docker-library/ruby/issues/75
 	apk add --no-cache --virtual .ruby-builddeps \
 		autoconf \
 		bison \
@@ -58,7 +57,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		readline-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.3-rc/slim-bullseye/Dockerfile
+++ b/3.3-rc/slim-bullseye/Dockerfile
@@ -51,7 +51,6 @@ RUN set -eux; \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
 		libncurses-dev \
-		libreadline-dev \
 		libxml2-dev \
 		libxslt-dev \
 		make \

--- a/3.3-rc/slim-buster/Dockerfile
+++ b/3.3-rc/slim-buster/Dockerfile
@@ -51,7 +51,6 @@ RUN set -eux; \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
 		libncurses-dev \
-		libreadline-dev \
 		libxml2-dev \
 		libxslt-dev \
 		make \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -59,7 +59,6 @@ ENV RUBY_DOWNLOAD_SHA256 {{ .sha256 }}
 RUN set -eux; \
 	\
 {{ if is_alpine then ( -}}
-# readline-dev vs libedit-dev: https://bugs.ruby-lang.org/issues/11869 and https://github.com/docker-library/ruby/issues/75
 	apk add --no-cache --virtual .ruby-builddeps \
 		autoconf \
 		bison \
@@ -83,7 +82,9 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+{{ if [ "3.0", "3.1", "3.2" ] | index(env.version | rtrimstr("-rc")) then ( -}}
 		readline-dev \
+{{ ) else "" end -}}
 		ruby \
 		tar \
 		xz \
@@ -106,7 +107,9 @@ RUN set -eux; \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
 		libncurses-dev \
+{{ if [ "3.0", "3.1", "3.2" ] | index(env.version | rtrimstr("-rc")) then ( -}}
 		libreadline-dev \
+{{ ) else "" end -}}
 		libxml2-dev \
 		libxslt-dev \
 		make \
@@ -218,7 +221,7 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
-{{ if is_alpine and "3.0" == env.version then ( -}}
+{{ if is_alpine and "3.0" == (env.version | rtrimstr("-rc")) then ( -}}
 	# fix builds on arm32v6/7 and s390x: https://github.com/docker-library/ruby/issues/308
 	# and don't break the other arches: https://github.com/docker-library/ruby/issues/365
 {{ if .rust.version then "" else ( -}}


### PR DESCRIPTION
Also, remove now unnecessary comment.

See https://github.com/ruby/ruby/blob/v3_3_0_preview1/NEWS.md#extreadline-is-retired

Refs #419