### PR TITLE
Workaround 3.3.0 crash on aarch64

### DIFF
--- a/3.3/alpine3.18/Dockerfile
+++ b/3.3/alpine3.18/Dockerfile
@@ -117,6 +117,13 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# workaround crash on arm64
+	# https://bugs.ruby-lang.org/issues/20085
+	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
+	wget -O 'arm64-fix.patch' 'https://github.com/ruby/ruby/commit/7f97e3540ce448b501bcbee15afac5f94bb22dd9.patch?full_index=1'; \
+	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
+	patch -p1 -i arm64-fix.patch; \
+	rm arm64-fix.patch; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/alpine3.19/Dockerfile
+++ b/3.3/alpine3.19/Dockerfile
@@ -117,6 +117,13 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# workaround crash on arm64
+	# https://bugs.ruby-lang.org/issues/20085
+	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
+	wget -O 'arm64-fix.patch' 'https://github.com/ruby/ruby/commit/7f97e3540ce448b501bcbee15afac5f94bb22dd9.patch?full_index=1'; \
+	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
+	patch -p1 -i arm64-fix.patch; \
+	rm arm64-fix.patch; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/bookworm/Dockerfile
+++ b/3.3/bookworm/Dockerfile
@@ -75,6 +75,13 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# workaround crash on arm64
+	# https://bugs.ruby-lang.org/issues/20085
+	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
+	wget -O 'arm64-fix.patch' 'https://github.com/ruby/ruby/commit/7f97e3540ce448b501bcbee15afac5f94bb22dd9.patch?full_index=1'; \
+	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
+	patch -p1 -i arm64-fix.patch; \
+	rm arm64-fix.patch; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/bullseye/Dockerfile
+++ b/3.3/bullseye/Dockerfile
@@ -75,6 +75,13 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# workaround crash on arm64
+	# https://bugs.ruby-lang.org/issues/20085
+	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
+	wget -O 'arm64-fix.patch' 'https://github.com/ruby/ruby/commit/7f97e3540ce448b501bcbee15afac5f94bb22dd9.patch?full_index=1'; \
+	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
+	patch -p1 -i arm64-fix.patch; \
+	rm arm64-fix.patch; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/slim-bookworm/Dockerfile
+++ b/3.3/slim-bookworm/Dockerfile
@@ -101,6 +101,13 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# workaround crash on arm64
+	# https://bugs.ruby-lang.org/issues/20085
+	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
+	wget -O 'arm64-fix.patch' 'https://github.com/ruby/ruby/commit/7f97e3540ce448b501bcbee15afac5f94bb22dd9.patch?full_index=1'; \
+	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
+	patch -p1 -i arm64-fix.patch; \
+	rm arm64-fix.patch; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/slim-bullseye/Dockerfile
+++ b/3.3/slim-bullseye/Dockerfile
@@ -101,6 +101,13 @@ RUN set -eux; \
 	mv file.c.new file.c; \
 	\
 	autoconf; \
+	# workaround crash on arm64
+	# https://bugs.ruby-lang.org/issues/20085
+	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
+	wget -O 'arm64-fix.patch' 'https://github.com/ruby/ruby/commit/7f97e3540ce448b501bcbee15afac5f94bb22dd9.patch?full_index=1'; \
+	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
+	patch -p1 -i arm64-fix.patch; \
+	rm arm64-fix.patch; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -253,6 +253,15 @@ RUN set -eux; \
 			;; \
 	esac; \
 {{ ) else "" end -}}
+{{ if .version == "3.3.0" then ( -}}
+	# workaround crash on arm64
+	# https://bugs.ruby-lang.org/issues/20085
+	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
+	wget -O 'arm64-fix.patch' 'https://github.com/ruby/ruby/commit/7f97e3540ce448b501bcbee15afac5f94bb22dd9.patch?full_index=1'; \
+	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
+	patch -p1 -i arm64-fix.patch; \
+	rm arm64-fix.patch; \
+{{ ) else "" end -}}
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \


### PR DESCRIPTION
Ruby 3.3.0 has a bug which crashs many practical programs on linux-aarch64 (especially on Linux VMs on macOS, e.g. Docker Desktop).
https://bugs.ruby-lang.org/issues/20085

This bug is fixed in upstream and is planned to be backported, but no date is given yet for the 3.3.1 release.
https://github.com/ruby/ruby/pull/9371

This patch workarounds this bug by passing ASFLAGS to ./configure as described in https://bugs.ruby-lang.org/issues/20085#note-5 .