### PR TITLE
Apply arm64 patch sooner so `autoconf` regenerates `configure` correctly

### DIFF
--- a/3.3/alpine3.18/Dockerfile
+++ b/3.3/alpine3.18/Dockerfile
@@ -116,7 +116,6 @@ RUN set -eux; \
 	} > file.c.new; \
 	mv file.c.new file.c; \
 	\
-	autoconf; \
 	# workaround crash on arm64
 	# https://bugs.ruby-lang.org/issues/20085
 	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
@@ -124,6 +123,8 @@ RUN set -eux; \
 	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
 	patch -p1 -i arm64-fix.patch; \
 	rm arm64-fix.patch; \
+	\
+	autoconf; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/alpine3.19/Dockerfile
+++ b/3.3/alpine3.19/Dockerfile
@@ -116,7 +116,6 @@ RUN set -eux; \
 	} > file.c.new; \
 	mv file.c.new file.c; \
 	\
-	autoconf; \
 	# workaround crash on arm64
 	# https://bugs.ruby-lang.org/issues/20085
 	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
@@ -124,6 +123,8 @@ RUN set -eux; \
 	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
 	patch -p1 -i arm64-fix.patch; \
 	rm arm64-fix.patch; \
+	\
+	autoconf; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/bookworm/Dockerfile
+++ b/3.3/bookworm/Dockerfile
@@ -74,7 +74,6 @@ RUN set -eux; \
 	} > file.c.new; \
 	mv file.c.new file.c; \
 	\
-	autoconf; \
 	# workaround crash on arm64
 	# https://bugs.ruby-lang.org/issues/20085
 	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
@@ -82,6 +81,8 @@ RUN set -eux; \
 	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
 	patch -p1 -i arm64-fix.patch; \
 	rm arm64-fix.patch; \
+	\
+	autoconf; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/bullseye/Dockerfile
+++ b/3.3/bullseye/Dockerfile
@@ -74,7 +74,6 @@ RUN set -eux; \
 	} > file.c.new; \
 	mv file.c.new file.c; \
 	\
-	autoconf; \
 	# workaround crash on arm64
 	# https://bugs.ruby-lang.org/issues/20085
 	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
@@ -82,6 +81,8 @@ RUN set -eux; \
 	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
 	patch -p1 -i arm64-fix.patch; \
 	rm arm64-fix.patch; \
+	\
+	autoconf; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/slim-bookworm/Dockerfile
+++ b/3.3/slim-bookworm/Dockerfile
@@ -100,7 +100,6 @@ RUN set -eux; \
 	} > file.c.new; \
 	mv file.c.new file.c; \
 	\
-	autoconf; \
 	# workaround crash on arm64
 	# https://bugs.ruby-lang.org/issues/20085
 	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
@@ -108,6 +107,8 @@ RUN set -eux; \
 	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
 	patch -p1 -i arm64-fix.patch; \
 	rm arm64-fix.patch; \
+	\
+	autoconf; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/3.3/slim-bullseye/Dockerfile
+++ b/3.3/slim-bullseye/Dockerfile
@@ -100,7 +100,6 @@ RUN set -eux; \
 	} > file.c.new; \
 	mv file.c.new file.c; \
 	\
-	autoconf; \
 	# workaround crash on arm64
 	# https://bugs.ruby-lang.org/issues/20085
 	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
@@ -108,6 +107,8 @@ RUN set -eux; \
 	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
 	patch -p1 -i arm64-fix.patch; \
 	rm arm64-fix.patch; \
+	\
+	autoconf; \
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \
 		--build="$gnuArch" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -238,6 +238,16 @@ RUN set -eux; \
 		cat file.c; \
 	} > file.c.new; \
 	mv file.c.new file.c; \
+{{ if .version == "3.3.0" then ( -}}
+	\
+	# workaround crash on arm64
+	# https://bugs.ruby-lang.org/issues/20085
+	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
+	wget -O 'arm64-fix.patch' 'https://github.com/ruby/ruby/commit/7f97e3540ce448b501bcbee15afac5f94bb22dd9.patch?full_index=1'; \
+	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
+	patch -p1 -i arm64-fix.patch; \
+	rm arm64-fix.patch; \
+{{ ) else "" end -}}
 	\
 	autoconf; \
 {{ if is_alpine and "3.0" == (env.version | rtrimstr("-rc")) then ( -}}
@@ -252,15 +262,6 @@ RUN set -eux; \
 			export LIBS='-lucontext'; \
 			;; \
 	esac; \
-{{ ) else "" end -}}
-{{ if .version == "3.3.0" then ( -}}
-	# workaround crash on arm64
-	# https://bugs.ruby-lang.org/issues/20085
-	# https://github.com/ruby/ruby/pull/9385 <- https://github.com/ruby/ruby/pull/9371
-	wget -O 'arm64-fix.patch' 'https://github.com/ruby/ruby/commit/7f97e3540ce448b501bcbee15afac5f94bb22dd9.patch?full_index=1'; \
-	echo '86bc65415fd62cb2272a4df249f39fb79db15617ad05c540e05a22f02eae73b3 *arm64-fix.patch' | sha256sum --check --strict; \
-	patch -p1 -i arm64-fix.patch; \
-	rm arm64-fix.patch; \
 {{ ) else "" end -}}
 	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
 	./configure \


### PR DESCRIPTION
Follow-up to https://github.com/docker-library/ruby/pull/439, see https://bugs.ruby-lang.org/issues/20085#note-30 :facepalm: