### PR TITLE
Revert RUBY_MAJOR refactoring for 3.0

### DIFF
--- a/3.0/alpine3.16/Dockerfile
+++ b/3.0/alpine3.16/Dockerfile
@@ -28,8 +28,8 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/
+ENV RUBY_MAJOR 3.0
 ENV RUBY_VERSION 3.0.7
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.7.tar.xz
 ENV RUBY_DOWNLOAD_SHA256 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
 
 # some of ruby's build scripts are written in ruby
@@ -67,7 +67,7 @@ RUN set -eux; \
 		zlib-dev \
 	; \
 	\
-	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
+	wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"; \
 	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
 	\
 	mkdir -p /usr/src/ruby; \

--- a/3.0/bullseye/Dockerfile
+++ b/3.0/bullseye/Dockerfile
@@ -17,8 +17,8 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/
+ENV RUBY_MAJOR 3.0
 ENV RUBY_VERSION 3.0.7
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.7.tar.xz
 ENV RUBY_DOWNLOAD_SHA256 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
 
 # some of ruby's build scripts are written in ruby
@@ -35,7 +35,7 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
+	wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"; \
 	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
 	\
 	mkdir -p /usr/src/ruby; \

--- a/3.0/buster/Dockerfile
+++ b/3.0/buster/Dockerfile
@@ -17,8 +17,8 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/
+ENV RUBY_MAJOR 3.0
 ENV RUBY_VERSION 3.0.7
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.7.tar.xz
 ENV RUBY_DOWNLOAD_SHA256 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
 
 # some of ruby's build scripts are written in ruby
@@ -35,7 +35,7 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
+	wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"; \
 	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
 	\
 	mkdir -p /usr/src/ruby; \

--- a/3.0/slim-bullseye/Dockerfile
+++ b/3.0/slim-bullseye/Dockerfile
@@ -31,8 +31,8 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/
+ENV RUBY_MAJOR 3.0
 ENV RUBY_VERSION 3.0.7
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.7.tar.xz
 ENV RUBY_DOWNLOAD_SHA256 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
 
 # some of ruby's build scripts are written in ruby
@@ -62,7 +62,7 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
+	wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"; \
 	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
 	\
 	mkdir -p /usr/src/ruby; \

--- a/3.0/slim-buster/Dockerfile
+++ b/3.0/slim-buster/Dockerfile
@@ -31,8 +31,8 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/
+ENV RUBY_MAJOR 3.0
 ENV RUBY_VERSION 3.0.7
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.0/ruby-3.0.7.tar.xz
 ENV RUBY_DOWNLOAD_SHA256 1748338373c4fad80129921080d904aca326e41bd9589b498aa5ee09fd575bab
 
 # some of ruby's build scripts are written in ruby
@@ -62,7 +62,7 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
+	wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"; \
 	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
 	\
 	mkdir -p /usr/src/ruby; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -50,13 +50,13 @@ RUN set -eux; \
 	} >> /usr/local/etc/gemrc
 
 ENV LANG C.UTF-8
-{{ if .version | . == "3.0.6" or . == "3.1.4" or . == "3.2.2" then ( -}}
+
+# https://www.ruby-lang.org/{{ .post | ltrimstr("/") }}
+{{ if env.version == "3.0" then ( -}}
 ENV RUBY_MAJOR {{ env.version }}
 ENV RUBY_VERSION {{ .version }}
 ENV RUBY_DOWNLOAD_SHA256 {{ .sha256.xz }}
 {{ ) else ( -}}
-
-# https://www.ruby-lang.org/{{ .post | ltrimstr("/") }}
 ENV RUBY_VERSION {{ .version }}
 ENV RUBY_DOWNLOAD_URL {{ .url.xz }}
 ENV RUBY_DOWNLOAD_SHA256 {{ .sha256.xz }}
@@ -203,7 +203,7 @@ RUN set -eux; \
 	fi; \
 {{ ) else "" end -}}
 	\
-{{ if .version | . == "3.0.6" or . == "3.1.4" or . == "3.2.2" then ( -}}
+{{ if env.version == "3.0" then ( -}}
 {{ if .url.xz != "https://cache.ruby-lang.org/pub/ruby/\(env.version | rtrimstr("-rc"))/ruby-\(.version).tar.xz" then error("url for \(.version) is not as expected!") else "" end -}}
 	wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"; \
 {{ ) else ( -}}


### PR DESCRIPTION
(since it's effectively EOL now except the possibility of a severe regression: https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/)

See https://github.com/docker-library/ruby/pull/435