### PR TITLE
Allow overriding ruby source url during build time

### DIFF
--- a/3.1/alpine3.18/Dockerfile
+++ b/3.1/alpine3.18/Dockerfile
@@ -28,9 +28,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-1-5-released/
-ENV RUBY_VERSION 3.1.5
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG RUBY_VERSION=3.1.5
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -68,7 +73,9 @@ RUN set -eux; \
 	; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.1/alpine3.19/Dockerfile
+++ b/3.1/alpine3.19/Dockerfile
@@ -28,9 +28,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-1-5-released/
-ENV RUBY_VERSION 3.1.5
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG RUBY_VERSION=3.1.5
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -68,7 +73,9 @@ RUN set -eux; \
 	; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.1/bookworm/Dockerfile
+++ b/3.1/bookworm/Dockerfile
@@ -17,9 +17,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-1-5-released/
-ENV RUBY_VERSION 3.1.5
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG RUBY_VERSION=3.1.5
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -36,7 +41,9 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.1/bullseye/Dockerfile
+++ b/3.1/bullseye/Dockerfile
@@ -17,9 +17,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-1-5-released/
-ENV RUBY_VERSION 3.1.5
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG RUBY_VERSION=3.1.5
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -36,7 +41,9 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.1/slim-bookworm/Dockerfile
+++ b/3.1/slim-bookworm/Dockerfile
@@ -31,9 +31,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-1-5-released/
-ENV RUBY_VERSION 3.1.5
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG RUBY_VERSION=3.1.5
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -63,7 +68,9 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.1/slim-bullseye/Dockerfile
+++ b/3.1/slim-bullseye/Dockerfile
@@ -31,9 +31,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-1-5-released/
-ENV RUBY_VERSION 3.1.5
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG RUBY_VERSION=3.1.5
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.5.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=f9375a45bdf1cc41298558e7ac6c367f7b6cdcccf7196618b21f0886ff583b91
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -63,7 +68,9 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.2/alpine3.18/Dockerfile
+++ b/3.2/alpine3.18/Dockerfile
@@ -28,9 +28,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/
-ENV RUBY_VERSION 3.2.4
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG RUBY_VERSION=3.2.4
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -90,7 +95,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.2/alpine3.19/Dockerfile
+++ b/3.2/alpine3.19/Dockerfile
@@ -28,9 +28,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/
-ENV RUBY_VERSION 3.2.4
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG RUBY_VERSION=3.2.4
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -90,7 +95,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.2/bookworm/Dockerfile
+++ b/3.2/bookworm/Dockerfile
@@ -17,9 +17,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/
-ENV RUBY_VERSION 3.2.4
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG RUBY_VERSION=3.2.4
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -58,7 +63,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.2/bullseye/Dockerfile
+++ b/3.2/bullseye/Dockerfile
@@ -17,9 +17,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/
-ENV RUBY_VERSION 3.2.4
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG RUBY_VERSION=3.2.4
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -58,7 +63,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.2/slim-bookworm/Dockerfile
+++ b/3.2/slim-bookworm/Dockerfile
@@ -31,9 +31,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/
-ENV RUBY_VERSION 3.2.4
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG RUBY_VERSION=3.2.4
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -85,7 +90,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.2/slim-bullseye/Dockerfile
+++ b/3.2/slim-bullseye/Dockerfile
@@ -31,9 +31,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/
-ENV RUBY_VERSION 3.2.4
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG RUBY_VERSION=3.2.4
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.2/ruby-3.2.4.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=e7f1653d653232ec433472489a91afbc7433c9f760cc822defe7437c9d95791b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -85,7 +90,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.3/alpine3.18/Dockerfile
+++ b/3.3/alpine3.18/Dockerfile
@@ -28,9 +28,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/
-ENV RUBY_VERSION 3.3.1
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG RUBY_VERSION=3.3.1
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -88,7 +93,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.3/alpine3.19/Dockerfile
+++ b/3.3/alpine3.19/Dockerfile
@@ -28,9 +28,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/
-ENV RUBY_VERSION 3.3.1
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG RUBY_VERSION=3.3.1
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -88,7 +93,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.3/bookworm/Dockerfile
+++ b/3.3/bookworm/Dockerfile
@@ -17,9 +17,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/
-ENV RUBY_VERSION 3.3.1
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG RUBY_VERSION=3.3.1
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -57,7 +62,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.3/bullseye/Dockerfile
+++ b/3.3/bullseye/Dockerfile
@@ -17,9 +17,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/
-ENV RUBY_VERSION 3.3.1
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG RUBY_VERSION=3.3.1
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -57,7 +62,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.3/slim-bookworm/Dockerfile
+++ b/3.3/slim-bookworm/Dockerfile
@@ -31,9 +31,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/
-ENV RUBY_VERSION 3.3.1
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG RUBY_VERSION=3.3.1
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -83,7 +88,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/3.3/slim-bullseye/Dockerfile
+++ b/3.3/slim-bullseye/Dockerfile
@@ -31,9 +31,14 @@ RUN set -eux; \
 ENV LANG C.UTF-8
 
 # https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/
-ENV RUBY_VERSION 3.3.1
-ENV RUBY_DOWNLOAD_URL https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
-ENV RUBY_DOWNLOAD_SHA256 0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG RUBY_VERSION=3.3.1
+ARG RUBY_DOWNLOAD_URL=https://cache.ruby-lang.org/pub/ruby/3.3/ruby-3.3.1.tar.xz
+ARG RUBY_DOWNLOAD_SHA256=0686941a3ec395a15ae2a852487b2a88e5fb8a5518e188df00d8d1bb71a6349b
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 
 # some of ruby's build scripts are written in ruby
 #   we purge system ruby later to make sure our final image uses what we just built
@@ -83,7 +88,9 @@ RUN set -eux; \
 	fi; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -57,9 +57,14 @@ ENV RUBY_MAJOR {{ env.version }}
 ENV RUBY_VERSION {{ .version }}
 ENV RUBY_DOWNLOAD_SHA256 {{ .sha256.xz }}
 {{ ) else ( -}}
-ENV RUBY_VERSION {{ .version }}
-ENV RUBY_DOWNLOAD_URL {{ .url.xz }}
-ENV RUBY_DOWNLOAD_SHA256 {{ .sha256.xz }}
+ARG RUBY_VERSION={{ .version }}
+ARG RUBY_DOWNLOAD_URL={{ .url.xz }}
+ARG RUBY_DOWNLOAD_SHA256={{ .sha256.xz }}
+ARG SKIP_CHECKSUM_CHECK=0
+ENV RUBY_VERSION=${RUBY_VERSION}
+ENV RUBY_DOWNLOAD_URL=${RUBY_DOWNLOAD_URL}
+ENV RUBY_DOWNLOAD_SHA256=${RUBY_DOWNLOAD_SHA256}
+ENV SKIP_CHECKSUM_CHECK=${SKIP_CHECKSUM_CHECK}
 {{ ) end -}}
 
 # some of ruby's build scripts are written in ruby
@@ -206,10 +211,13 @@ RUN set -eux; \
 {{ if env.version == "3.0" then ( -}}
 {{ if .url.xz != "https://cache.ruby-lang.org/pub/ruby/\(env.version | rtrimstr("-rc"))/ruby-\(.version).tar.xz" then error("url for \(.version) is not as expected!") else "" end -}}
 	wget -O ruby.tar.xz "https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR%-rc}/ruby-$RUBY_VERSION.tar.xz"; \
+	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
 {{ ) else ( -}}
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
+  if [[ "$SKIP_CHECKSUM_CHECK" -ne "1" ]]; then \
+		echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
+  fi; \
 {{ ) end -}}
-	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
 	\
 	mkdir -p /usr/src/ruby; \
 	tar -xJf ruby.tar.xz -C /usr/src/ruby --strip-components=1; \


### PR DESCRIPTION
This makes it possible to build against ruby master (as long as there are no additional changes that would need to be made)

I understand that as per #222 providing head images directly is not feasable. This makes it one step simpler to use these yourself if you want to. I believe it doesn't add too much complexity.

Due to the volatility of the nighly builds I added a build arg to skip the checksum check. It wouldn't really work that well otherwise.

A sample `docker-compose.yml` to demonstrate:

```yaml
services:
  ruby:
    build:
      args:
        RUBY_VERSION: 3.4-dev
        RUBY_DOWNLOAD_URL: https://cache.ruby-lang.org/pub/ruby/snapshot/snapshot-master.tar.xz
        SKIP_CHECKSUM_CHECK: 1
      dockerfile: 3.3/alpine3.19/Dockerfile
```

It doesn't work for the 3.0 images since they have a different format but it's EOL anyways and soon to be removed I imagine.