### PR TITLE
Remove alpine isnan/isinf workaround

### DIFF
--- a/3.1/alpine3.19/Dockerfile
+++ b/3.1/alpine3.19/Dockerfile
@@ -84,9 +84,6 @@ RUN set -eux; \
 	patch -p1 -i thread-stack-fix.patch; \
 	rm thread-stack-fix.patch; \
 	\
-# the configure script does not detect isnan/isinf as macros
-	export ac_cv_func_isnan=yes ac_cv_func_isinf=yes; \
-	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	{ \

--- a/3.1/alpine3.20/Dockerfile
+++ b/3.1/alpine3.20/Dockerfile
@@ -84,9 +84,6 @@ RUN set -eux; \
 	patch -p1 -i thread-stack-fix.patch; \
 	rm thread-stack-fix.patch; \
 	\
-# the configure script does not detect isnan/isinf as macros
-	export ac_cv_func_isnan=yes ac_cv_func_isinf=yes; \
-	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	{ \

--- a/3.2/alpine3.19/Dockerfile
+++ b/3.2/alpine3.19/Dockerfile
@@ -106,9 +106,6 @@ RUN set -eux; \
 	patch -p1 -i thread-stack-fix.patch; \
 	rm thread-stack-fix.patch; \
 	\
-# the configure script does not detect isnan/isinf as macros
-	export ac_cv_func_isnan=yes ac_cv_func_isinf=yes; \
-	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	{ \

--- a/3.2/alpine3.20/Dockerfile
+++ b/3.2/alpine3.20/Dockerfile
@@ -106,9 +106,6 @@ RUN set -eux; \
 	patch -p1 -i thread-stack-fix.patch; \
 	rm thread-stack-fix.patch; \
 	\
-# the configure script does not detect isnan/isinf as macros
-	export ac_cv_func_isnan=yes ac_cv_func_isinf=yes; \
-	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	{ \

--- a/3.3/alpine3.19/Dockerfile
+++ b/3.3/alpine3.19/Dockerfile
@@ -104,9 +104,6 @@ RUN set -eux; \
 	patch -p1 -i thread-stack-fix.patch; \
 	rm thread-stack-fix.patch; \
 	\
-# the configure script does not detect isnan/isinf as macros
-	export ac_cv_func_isnan=yes ac_cv_func_isinf=yes; \
-	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	{ \

--- a/3.3/alpine3.20/Dockerfile
+++ b/3.3/alpine3.20/Dockerfile
@@ -104,9 +104,6 @@ RUN set -eux; \
 	patch -p1 -i thread-stack-fix.patch; \
 	rm thread-stack-fix.patch; \
 	\
-# the configure script does not detect isnan/isinf as macros
-	export ac_cv_func_isnan=yes ac_cv_func_isinf=yes; \
-	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	{ \

--- a/3.4-rc/alpine3.19/Dockerfile
+++ b/3.4-rc/alpine3.19/Dockerfile
@@ -104,9 +104,6 @@ RUN set -eux; \
 	patch -p1 -i thread-stack-fix.patch; \
 	rm thread-stack-fix.patch; \
 	\
-# the configure script does not detect isnan/isinf as macros
-	export ac_cv_func_isnan=yes ac_cv_func_isinf=yes; \
-	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	{ \

--- a/3.4-rc/alpine3.20/Dockerfile
+++ b/3.4-rc/alpine3.20/Dockerfile
@@ -104,9 +104,6 @@ RUN set -eux; \
 	patch -p1 -i thread-stack-fix.patch; \
 	rm thread-stack-fix.patch; \
 	\
-# the configure script does not detect isnan/isinf as macros
-	export ac_cv_func_isnan=yes ac_cv_func_isinf=yes; \
-	\
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir
 	{ \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -215,9 +215,6 @@ RUN set -eux; \
 	patch -p1 -i thread-stack-fix.patch; \
 	rm thread-stack-fix.patch; \
 	\
-# the configure script does not detect isnan/isinf as macros
-	export ac_cv_func_isnan=yes ac_cv_func_isinf=yes; \
-	\
 {{ ) else "" end -}}
 # hack in "ENABLE_PATH_CHECK" disabling to suppress:
 #   warning: Insecure world writable dir


### PR DESCRIPTION
I believe this was fixed with https://github.com/ruby/ruby/commit/74f94b3e6ebf15b76f3b357e754095412b006e94
https://bugs.ruby-lang.org/issues/15595

This was shipped with Ruby 2.7, so it should be unnecessary now. I'll check the build output if that is indeed the case.