### PR TITLE
Remove runtime dependencies from slim and alpine variants

### DIFF
--- a/3.1/alpine3.20/Dockerfile
+++ b/3.1/alpine3.20/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.20
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -45,6 +34,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -56,6 +46,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \

--- a/3.1/alpine3.21/Dockerfile
+++ b/3.1/alpine3.21/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.21
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -45,6 +34,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -56,6 +46,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \

--- a/3.1/slim-bookworm/Dockerfile
+++ b/3.1/slim-bookworm/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -44,18 +37,24 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.1/slim-bullseye/Dockerfile
+++ b/3.1/slim-bullseye/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -44,18 +37,24 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.2/alpine3.20/Dockerfile
+++ b/3.2/alpine3.20/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.20
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -45,6 +34,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -56,6 +46,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \

--- a/3.2/alpine3.21/Dockerfile
+++ b/3.2/alpine3.21/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.21
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -45,6 +34,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -56,6 +46,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \

--- a/3.2/slim-bookworm/Dockerfile
+++ b/3.2/slim-bookworm/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -44,18 +37,24 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.2/slim-bullseye/Dockerfile
+++ b/3.2/slim-bullseye/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -44,18 +37,24 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.3/alpine3.20/Dockerfile
+++ b/3.3/alpine3.20/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.20
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -44,6 +33,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -55,6 +45,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.3/alpine3.21/Dockerfile
+++ b/3.3/alpine3.21/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.21
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -44,6 +33,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -55,6 +45,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.3/slim-bookworm/Dockerfile
+++ b/3.3/slim-bookworm/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -43,17 +36,23 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.3/slim-bullseye/Dockerfile
+++ b/3.3/slim-bullseye/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -43,17 +36,23 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.4/alpine3.20/Dockerfile
+++ b/3.4/alpine3.20/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.20
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -44,6 +33,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -55,6 +45,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.4/alpine3.21/Dockerfile
+++ b/3.4/alpine3.21/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.21
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -44,6 +33,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -55,6 +45,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.4/slim-bookworm/Dockerfile
+++ b/3.4/slim-bookworm/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -43,17 +36,23 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.4/slim-bullseye/Dockerfile
+++ b/3.4/slim-bullseye/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -43,17 +36,23 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,30 +13,11 @@ FROM debian:{{ env.variant | ltrimstr("slim-") }}-slim
 FROM buildpack-deps:{{ env.variant }}
 {{ ) end -}}
 
-{{ if is_alpine then ( -}}
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
-{{ ) elif is_slim then ( -}}
+{{ if is_slim then ( -}}
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -73,6 +54,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -84,6 +66,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 {{ if env.version | rtrimstr("-rc") | IN("3.1", "3.2") then ( -}}
 		readline-dev \
 {{ ) else "" end -}}
@@ -106,20 +90,26 @@ RUN set -eux; \
 		ruby \
 {{ if is_slim then ( -}}
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 {{ if env.version | rtrimstr("-rc") | IN("3.1", "3.2") then ( -}}
 		libreadline-dev \
 {{ ) else "" end -}}
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 {{ ) else "" end -}}
 	; \
 	rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
These were never intended to be part of the "interface" of the `slim` and `alpine` images -- they were included before we had fancy `ldd`/`scanelf`-based runtime dependency inclusion, and were a metapackage that helped us avoid the complexity of `libyaml3` vs `libyaml4` (and making sure we install the correct one).  This moves them to explicit build-time dependencies accordingly, as they should've always been.

Closes https://github.com/docker-library/ruby/issues/492
Refs:
- https://github.com/docker-library/ruby/pull/349
- https://github.com/docker-library/ruby/pull/60
- https://github.com/docker-library/ruby/pull/33
- https://github.com/docker-library/ruby/issues/492#issuecomment-2576425196