### PR TITLE
Revert "Remove runtime dependencies from slim and alpine variants"

### DIFF
--- a/3.1/alpine3.20/Dockerfile
+++ b/3.1/alpine3.20/Dockerfile
@@ -6,6 +6,17 @@
 
 FROM alpine:3.20
 
+RUN set -eux; \
+	apk add --no-cache \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	;
+
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -34,7 +45,6 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -46,8 +56,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		yaml-dev \
-		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \

--- a/3.1/alpine3.20/Dockerfile
+++ b/3.1/alpine3.20/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.20
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -45,6 +34,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -56,6 +46,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \
@@ -100,6 +92,19 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	apk add --no-cache --virtual .ruby-493-backcompat \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	; \
+	\
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
 			| tr ',' '\n' \
@@ -114,7 +119,7 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if \
 		apk --no-network list --installed \
-			| grep -v '^[.]ruby-rundeps' \
+			| grep -v '^[.]ruby-' \
 			| grep -i ruby \
 	; then \
 		exit 1; \

--- a/3.1/alpine3.21/Dockerfile
+++ b/3.1/alpine3.21/Dockerfile
@@ -6,6 +6,17 @@
 
 FROM alpine:3.21
 
+RUN set -eux; \
+	apk add --no-cache \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	;
+
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -34,7 +45,6 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -46,8 +56,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		yaml-dev \
-		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \

--- a/3.1/alpine3.21/Dockerfile
+++ b/3.1/alpine3.21/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.21
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -45,6 +34,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -56,6 +46,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \
@@ -100,6 +92,19 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	apk add --no-cache --virtual .ruby-493-backcompat \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	; \
+	\
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
 			| tr ',' '\n' \
@@ -114,7 +119,7 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if \
 		apk --no-network list --installed \
-			| grep -v '^[.]ruby-rundeps' \
+			| grep -v '^[.]ruby-' \
 			| grep -i ruby \
 	; then \
 		exit 1; \

--- a/3.1/bookworm/Dockerfile
+++ b/3.1/bookworm/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
 	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
@@ -71,6 +70,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.1/bullseye/Dockerfile
+++ b/3.1/bullseye/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
 	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
@@ -71,6 +70,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.1/slim-bookworm/Dockerfile
+++ b/3.1/slim-bookworm/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -44,20 +37,25 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
 	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
@@ -87,6 +85,20 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	savedAptMark="$savedAptMark \
+		bzip2 \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	"; \
+	apt-get install -y --no-install-recommends $savedAptMark; \
+	\
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark > /dev/null; \
 	find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
@@ -98,6 +110,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.1/slim-bookworm/Dockerfile
+++ b/3.1/slim-bookworm/Dockerfile
@@ -9,7 +9,14 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		bzip2 \
 		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -37,24 +44,18 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
-		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
-		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
-		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.1/slim-bullseye/Dockerfile
+++ b/3.1/slim-bullseye/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -44,20 +37,25 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	wget -O ruby.tar.xz "$RUBY_DOWNLOAD_URL"; \
 	echo "$RUBY_DOWNLOAD_SHA256 *ruby.tar.xz" | sha256sum --check --strict; \
@@ -87,6 +85,20 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	savedAptMark="$savedAptMark \
+		bzip2 \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	"; \
+	apt-get install -y --no-install-recommends $savedAptMark; \
+	\
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark > /dev/null; \
 	find /usr/local -type f -executable -not \( -name '*tkinter*' \) -exec ldd '{}' ';' \
@@ -98,6 +110,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.1/slim-bullseye/Dockerfile
+++ b/3.1/slim-bullseye/Dockerfile
@@ -9,7 +9,14 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		bzip2 \
 		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -37,24 +44,18 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
-		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
-		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
-		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.2/alpine3.20/Dockerfile
+++ b/3.2/alpine3.20/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.20
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -45,6 +34,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -56,6 +46,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \
@@ -123,6 +115,19 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	apk add --no-cache --virtual .ruby-493-backcompat \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	; \
+	\
 	rm -rf /tmp/rust; \
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
@@ -138,7 +143,7 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if \
 		apk --no-network list --installed \
-			| grep -v '^[.]ruby-rundeps' \
+			| grep -v '^[.]ruby-' \
 			| grep -i ruby \
 	; then \
 		exit 1; \

--- a/3.2/alpine3.20/Dockerfile
+++ b/3.2/alpine3.20/Dockerfile
@@ -6,6 +6,17 @@
 
 FROM alpine:3.20
 
+RUN set -eux; \
+	apk add --no-cache \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	;
+
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -34,7 +45,6 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -46,8 +56,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		yaml-dev \
-		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \

--- a/3.2/alpine3.21/Dockerfile
+++ b/3.2/alpine3.21/Dockerfile
@@ -6,6 +6,17 @@
 
 FROM alpine:3.21
 
+RUN set -eux; \
+	apk add --no-cache \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	;
+
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -34,7 +45,6 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -46,8 +56,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		yaml-dev \
-		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \

--- a/3.2/alpine3.21/Dockerfile
+++ b/3.2/alpine3.21/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.21
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -45,6 +34,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -56,6 +46,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		readline-dev \
 		ruby \
 		tar \
@@ -123,6 +115,19 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	apk add --no-cache --virtual .ruby-493-backcompat \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	; \
+	\
 	rm -rf /tmp/rust; \
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
@@ -138,7 +143,7 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if \
 		apk --no-network list --installed \
-			| grep -v '^[.]ruby-rundeps' \
+			| grep -v '^[.]ruby-' \
 			| grep -i ruby \
 	; then \
 		exit 1; \

--- a/3.2/bookworm/Dockerfile
+++ b/3.2/bookworm/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -95,6 +94,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.2/bullseye/Dockerfile
+++ b/3.2/bullseye/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -95,6 +94,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.2/slim-bookworm/Dockerfile
+++ b/3.2/slim-bookworm/Dockerfile
@@ -9,7 +9,14 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		bzip2 \
 		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -37,24 +44,18 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
-		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
-		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
-		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.2/slim-bookworm/Dockerfile
+++ b/3.2/slim-bookworm/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -44,20 +37,25 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -110,6 +108,20 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	savedAptMark="$savedAptMark \
+		bzip2 \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	"; \
+	apt-get install -y --no-install-recommends $savedAptMark; \
+	\
 	rm -rf /tmp/rust; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark > /dev/null; \
@@ -122,6 +134,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.2/slim-bullseye/Dockerfile
+++ b/3.2/slim-bullseye/Dockerfile
@@ -9,7 +9,14 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		bzip2 \
 		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -37,24 +44,18 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
-		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
-		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
-		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.2/slim-bullseye/Dockerfile
+++ b/3.2/slim-bullseye/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -44,20 +37,25 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 		libreadline-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -110,6 +108,20 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	savedAptMark="$savedAptMark \
+		bzip2 \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	"; \
+	apt-get install -y --no-install-recommends $savedAptMark; \
+	\
 	rm -rf /tmp/rust; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark > /dev/null; \
@@ -122,6 +134,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.3/alpine3.20/Dockerfile
+++ b/3.3/alpine3.20/Dockerfile
@@ -6,6 +6,17 @@
 
 FROM alpine:3.20
 
+RUN set -eux; \
+	apk add --no-cache \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	;
+
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -33,7 +44,6 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -45,8 +55,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		yaml-dev \
-		zlib-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.3/alpine3.20/Dockerfile
+++ b/3.3/alpine3.20/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.20
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -44,6 +33,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -55,6 +45,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		ruby \
 		tar \
 		xz \
@@ -121,6 +113,19 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	apk add --no-cache --virtual .ruby-493-backcompat \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	; \
+	\
 	rm -rf /tmp/rust; \
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
@@ -136,7 +141,7 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if \
 		apk --no-network list --installed \
-			| grep -v '^[.]ruby-rundeps' \
+			| grep -v '^[.]ruby-' \
 			| grep -i ruby \
 	; then \
 		exit 1; \

--- a/3.3/alpine3.21/Dockerfile
+++ b/3.3/alpine3.21/Dockerfile
@@ -6,6 +6,17 @@
 
 FROM alpine:3.21
 
+RUN set -eux; \
+	apk add --no-cache \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	;
+
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -33,7 +44,6 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -45,8 +55,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		yaml-dev \
-		zlib-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.3/alpine3.21/Dockerfile
+++ b/3.3/alpine3.21/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.21
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -44,6 +33,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -55,6 +45,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		ruby \
 		tar \
 		xz \
@@ -121,6 +113,19 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	apk add --no-cache --virtual .ruby-493-backcompat \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	; \
+	\
 	rm -rf /tmp/rust; \
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
@@ -136,7 +141,7 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if \
 		apk --no-network list --installed \
-			| grep -v '^[.]ruby-rundeps' \
+			| grep -v '^[.]ruby-' \
 			| grep -i ruby \
 	; then \
 		exit 1; \

--- a/3.3/bookworm/Dockerfile
+++ b/3.3/bookworm/Dockerfile
@@ -29,7 +29,6 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -94,6 +93,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.3/bullseye/Dockerfile
+++ b/3.3/bullseye/Dockerfile
@@ -29,7 +29,6 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -94,6 +93,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.3/slim-bookworm/Dockerfile
+++ b/3.3/slim-bookworm/Dockerfile
@@ -9,7 +9,14 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		bzip2 \
 		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -36,23 +43,17 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
-		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
-		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
-		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.3/slim-bookworm/Dockerfile
+++ b/3.3/slim-bookworm/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -43,19 +36,24 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -108,6 +106,20 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	savedAptMark="$savedAptMark \
+		bzip2 \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	"; \
+	apt-get install -y --no-install-recommends $savedAptMark; \
+	\
 	rm -rf /tmp/rust; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark > /dev/null; \
@@ -120,6 +132,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.3/slim-bullseye/Dockerfile
+++ b/3.3/slim-bullseye/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -43,19 +36,24 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -108,6 +106,20 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	savedAptMark="$savedAptMark \
+		bzip2 \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	"; \
+	apt-get install -y --no-install-recommends $savedAptMark; \
+	\
 	rm -rf /tmp/rust; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark > /dev/null; \
@@ -120,6 +132,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.3/slim-bullseye/Dockerfile
+++ b/3.3/slim-bullseye/Dockerfile
@@ -9,7 +9,14 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		bzip2 \
 		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -36,23 +43,17 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
-		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
-		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
-		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.4/alpine3.20/Dockerfile
+++ b/3.4/alpine3.20/Dockerfile
@@ -6,6 +6,17 @@
 
 FROM alpine:3.20
 
+RUN set -eux; \
+	apk add --no-cache \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	;
+
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -33,7 +44,6 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -45,8 +55,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		yaml-dev \
-		zlib-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.4/alpine3.20/Dockerfile
+++ b/3.4/alpine3.20/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.20
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -44,6 +33,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -55,6 +45,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		ruby \
 		tar \
 		xz \
@@ -121,6 +113,19 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	apk add --no-cache --virtual .ruby-493-backcompat \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	; \
+	\
 	rm -rf /tmp/rust; \
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
@@ -136,7 +141,7 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if \
 		apk --no-network list --installed \
-			| grep -v '^[.]ruby-rundeps' \
+			| grep -v '^[.]ruby-' \
 			| grep -i ruby \
 	; then \
 		exit 1; \

--- a/3.4/alpine3.21/Dockerfile
+++ b/3.4/alpine3.21/Dockerfile
@@ -6,6 +6,17 @@
 
 FROM alpine:3.21
 
+RUN set -eux; \
+	apk add --no-cache \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	;
+
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -33,7 +44,6 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -45,8 +55,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		yaml-dev \
-		zlib-dev \
 		ruby \
 		tar \
 		xz \

--- a/3.4/alpine3.21/Dockerfile
+++ b/3.4/alpine3.21/Dockerfile
@@ -6,17 +6,6 @@
 
 FROM alpine:3.21
 
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
 # skip installing gem documentation with `gem install`/`gem update`
 RUN set -eux; \
 	mkdir -p /usr/local/etc; \
@@ -44,6 +33,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -55,6 +45,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 		ruby \
 		tar \
 		xz \
@@ -121,6 +113,19 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	apk add --no-cache --virtual .ruby-493-backcompat \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	; \
+	\
 	rm -rf /tmp/rust; \
 	runDeps="$( \
 		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
@@ -136,7 +141,7 @@ RUN set -eux; \
 # verify we have no "ruby" packages installed
 	if \
 		apk --no-network list --installed \
-			| grep -v '^[.]ruby-rundeps' \
+			| grep -v '^[.]ruby-' \
 			| grep -i ruby \
 	; then \
 		exit 1; \

--- a/3.4/bookworm/Dockerfile
+++ b/3.4/bookworm/Dockerfile
@@ -29,7 +29,6 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -94,6 +93,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.4/bullseye/Dockerfile
+++ b/3.4/bullseye/Dockerfile
@@ -29,7 +29,6 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -94,6 +93,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.4/slim-bookworm/Dockerfile
+++ b/3.4/slim-bookworm/Dockerfile
@@ -9,7 +9,14 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		bzip2 \
 		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -36,23 +43,17 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
-		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
-		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
-		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/3.4/slim-bookworm/Dockerfile
+++ b/3.4/slim-bookworm/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bookworm-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -43,19 +36,24 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -108,6 +106,20 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	savedAptMark="$savedAptMark \
+		bzip2 \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	"; \
+	apt-get install -y --no-install-recommends $savedAptMark; \
+	\
 	rm -rf /tmp/rust; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark > /dev/null; \
@@ -120,6 +132,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.4/slim-bullseye/Dockerfile
+++ b/3.4/slim-bullseye/Dockerfile
@@ -9,14 +9,7 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -43,19 +36,24 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	\
 	rustArch=; \
 	dpkgArch="$(dpkg --print-architecture)"; \
@@ -108,6 +106,20 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+	savedAptMark="$savedAptMark \
+		bzip2 \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	"; \
+	apt-get install -y --no-install-recommends $savedAptMark; \
+	\
 	rm -rf /tmp/rust; \
 	apt-mark auto '.*' > /dev/null; \
 	apt-mark manual $savedAptMark > /dev/null; \
@@ -120,6 +132,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 	cd /; \
 	rm -r /usr/src/ruby; \

--- a/3.4/slim-bullseye/Dockerfile
+++ b/3.4/slim-bullseye/Dockerfile
@@ -9,7 +9,14 @@ FROM debian:bullseye-slim
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		bzip2 \
 		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -36,23 +43,17 @@ RUN set -eux; \
 		libgdbm-dev \
 		ruby \
 		autoconf \
-		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
-		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
-		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,11 +13,30 @@ FROM debian:{{ env.variant | ltrimstr("slim-") }}-slim
 FROM buildpack-deps:{{ env.variant }}
 {{ ) end -}}
 
-{{ if is_slim then ( -}}
+{{ if is_alpine then ( -}}
+RUN set -eux; \
+	apk add --no-cache \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	;
+
+{{ ) elif is_slim then ( -}}
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
+		bzip2 \
 		ca-certificates \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -54,7 +73,6 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
-		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -66,8 +84,6 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
-		yaml-dev \
-		zlib-dev \
 {{ if env.version | rtrimstr("-rc") | IN("3.1", "3.2") then ( -}}
 		readline-dev \
 {{ ) else "" end -}}
@@ -90,26 +106,20 @@ RUN set -eux; \
 		ruby \
 {{ if is_slim then ( -}}
 		autoconf \
-		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
-		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
-		libgmp-dev \
 		libncurses-dev \
 {{ if env.version | rtrimstr("-rc") | IN("3.1", "3.2") then ( -}}
 		libreadline-dev \
 {{ ) else "" end -}}
-		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
-		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
-		zlib1g-dev \
 {{ ) else "" end -}}
 	; \
 	rm -rf /var/lib/apt/lists/*; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,30 +13,11 @@ FROM debian:{{ env.variant | ltrimstr("slim-") }}-slim
 FROM buildpack-deps:{{ env.variant }}
 {{ ) end -}}
 
-{{ if is_alpine then ( -}}
-RUN set -eux; \
-	apk add --no-cache \
-		bzip2 \
-		ca-certificates \
-		gmp-dev \
-		libffi-dev \
-		procps \
-		yaml-dev \
-		zlib-dev \
-	;
-
-{{ ) elif is_slim then ( -}}
+{{ if is_slim then ( -}}
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		bzip2 \
 		ca-certificates \
-		libffi-dev \
-		libgmp-dev \
-		libssl-dev \
-		libyaml-dev \
-		procps \
-		zlib1g-dev \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -73,6 +54,7 @@ RUN set -eux; \
 		gcc \
 		gdbm-dev \
 		glib-dev \
+		gmp-dev \
 		libc-dev \
 		libffi-dev \
 		libxml2-dev \
@@ -84,6 +66,8 @@ RUN set -eux; \
 		openssl-dev \
 		patch \
 		procps \
+		yaml-dev \
+		zlib-dev \
 {{ if env.version | rtrimstr("-rc") | IN("3.1", "3.2") then ( -}}
 		readline-dev \
 {{ ) else "" end -}}
@@ -106,23 +90,28 @@ RUN set -eux; \
 		ruby \
 {{ if is_slim then ( -}}
 		autoconf \
+		bzip2 \
 		g++ \
 		gcc \
 		libbz2-dev \
+		libffi-dev \
 		libgdbm-compat-dev \
 		libglib2.0-dev \
+		libgmp-dev \
 		libncurses-dev \
 {{ if env.version | rtrimstr("-rc") | IN("3.1", "3.2") then ( -}}
 		libreadline-dev \
 {{ ) else "" end -}}
+		libssl-dev \
 		libxml2-dev \
 		libxslt-dev \
+		libyaml-dev \
 		make \
 		wget \
 		xz-utils \
+		zlib1g-dev \
 {{ ) else "" end -}}
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 {{ ) end -}}
 {{ if .rust.version then ( -}}
 	\
@@ -235,6 +224,34 @@ RUN set -eux; \
 	make -j "$(nproc)"; \
 	make install; \
 	\
+{{ if (is_alpine or is_slim) and (.version | IN("3.1.6", "3.2.6", "3.3.6", "3.4.1")) then ( -}}
+# temporary backwards compatibility shim (will go away in the next patch release; please update/adjust accordingly); see:
+# - https://github.com/docker-library/ruby/pull/493
+# - https://github.com/docker-library/ruby/pull/497
+{{ if is_alpine then ( -}}
+	apk add --no-cache --virtual .ruby-493-backcompat \
+		bzip2 \
+		ca-certificates \
+		gmp-dev \
+		libffi-dev \
+		procps \
+		yaml-dev \
+		zlib-dev \
+	; \
+{{ ) else ( -}}
+	savedAptMark="$savedAptMark \
+		bzip2 \
+		libffi-dev \
+		libgmp-dev \
+		libssl-dev \
+		libyaml-dev \
+		procps \
+		zlib1g-dev \
+	"; \
+	apt-get install -y --no-install-recommends $savedAptMark; \
+{{ ) end -}}
+	\
+{{ ) else "" end -}}
 {{ if .rust.version then ( -}}
 	rm -rf /tmp/rust; \
 {{ ) else "" end -}}
@@ -259,6 +276,7 @@ RUN set -eux; \
 		| xargs -r apt-mark manual \
 	; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
 {{ ) end -}}
 	\
 	cd /; \
@@ -267,7 +285,7 @@ RUN set -eux; \
 {{ if is_alpine then ( -}}
 	if \
 		apk --no-network list --installed \
-			| grep -v '^[.]ruby-rundeps' \
+			| grep -v '^[.]ruby-' \
 			| grep -i ruby \
 	; then \
 		exit 1; \


### PR DESCRIPTION
This reverts commit 7f078b1b01338e19130eb8b01cb7f35153ba6b04. (https://github.com/docker-library/ruby/pull/493)

It looks like this change is too disruptive. For example, modern rails apps all transitively depend in `psych` which requires libyaml. Coincidentally my own builds would fail with this.

I still think this change makes sense, but should probably only be part of the next Ruby version so it doesn't suddently break for lots of people.

Closes #495, closes #496