### PR TITLE
Update v4_0_0_preview2 to v4.0.0-preview2

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -214,7 +214,7 @@
     "version": "4.0.0-preview2",
     "date": "2025-11-17",
     "post": "/en/news/2025/11/17/ruby-4-0-0-preview2-released/",
-    "tag": "v4_0_0_preview2",
+    "tag": "v4.0.0-preview2",
     "stats": {
       "files_changed": 3607,
       "insertions": 197451,


### PR DESCRIPTION
The `v4_0_0_preview2` git tag has been renamed to `v4.0.0-preview2`.

https://bugs.ruby-lang.org/issues/21774